### PR TITLE
Add Start wrapper and centralized settings

### DIFF
--- a/LLM_Extreme_Context.py
+++ b/LLM_Extreme_Context.py
@@ -8,42 +8,14 @@ from bs4 import BeautifulSoup, Comment
 from typing import List, Dict, Optional
 from tree_sitter import Parser
 import pathspec
-from tree_sitter_language_pack import  get_parser
+from tree_sitter_language_pack import get_parser
 from tqdm import tqdm
 import re
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# === Settings loader ===
-def load_settings():
-    """Load settings from settings.json with fallback defaults"""
-    default_settings = {
-        "llm_model": "BAAI/bge-small-en",
-        "output_dir": "extracted",
-        "default_project": "ComfyUI",
-        "embedding_dim": 384,
-        "top_k_results": 20,
-        "chunk_size": 1000,
-        "context_hops": 1,
-        "max_neighbors": 5,
-        "allowed_extensions": [".py", ".js", ".ts", ".json", ".yaml", ".yml", ".md", ".txt", ".html", ".htm"],
-        "exclude_dirs": ["__pycache__", ".git", "node_modules", ".venv", "venv", "dist", "build", ".idea", ".vscode", ".pytest_cache"]
-    }
-    settings_path = "settings.json"
-    if os.path.exists(settings_path):
-        try:
-            with open(settings_path, "r", encoding="utf-8") as f:
-                settings = json.load(f)
-                default_settings.update(settings)
-        except (json.JSONDecodeError, IOError) as e:
-            logger.warning(f"Could not load settings.json: {e}. Using defaults.")
-    else:
-        logger.info("settings.json not found. Using default settings.")
-    return default_settings
-
-# Load settings
-SETTINGS = load_settings()
+from Start import SETTINGS
 
 # === Files included and excluded in search ===
 ALLOWED_EXTENSIONS = set(SETTINGS["allowed_extensions"])

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ This project uses a `settings.json` file for configuration. To get started:
 - **chunk_size**: Text chunk size for processing (default: 1000)
 - **allowed_extensions**: File extensions to include in processing
 - **exclude_dirs**: Directories to exclude from processing
+- **local_model_path**: Optional path to a local embedding model
 
 ### Files
 
 - `LLM_Extream_Context.py`: Main extraction script
+- `Start.py`: Entry point for running other utilities
 - `generate_embeddings.py`: Generate embeddings from call graph
 - `query_sniper.py`: Interactive query interface
 - `inspect_graph.py`: Graph analysis and visualization
@@ -30,3 +32,4 @@ This project uses a `settings.json` file for configuration. To get started:
 ## Usage
 
 The `settings.json` file is automatically loaded by all scripts. If the file doesn't exist, default values are used.
+Run `python Start.py <command>` to execute tools where `<command>` is `generate`, `query`, or `inspect`.

--- a/Start.py
+++ b/Start.py
@@ -1,0 +1,85 @@
+import os
+import json
+import argparse
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def load_settings():
+    """Load settings from settings.json with fallback defaults."""
+    default_settings = {
+        "llm_model": "BAAI/bge-small-en",
+        "output_dir": "extracted",
+        "default_project": "ComfyUI",
+        "embedding_dim": 384,
+        "top_k_results": 20,
+        "chunk_size": 1000,
+        "context_hops": 1,
+        "max_neighbors": 5,
+        "allowed_extensions": [
+            ".py", ".js", ".ts", ".json", ".yaml", ".yml",
+            ".md", ".txt", ".html", ".htm"
+        ],
+        "exclude_dirs": [
+            "__pycache__", ".git", "node_modules", ".venv", "venv",
+            "dist", "build", ".idea", ".vscode", ".pytest_cache"
+        ],
+        "local_model_path": ""
+    }
+
+    settings_path = "settings.json"
+    if os.path.exists(settings_path):
+        try:
+            with open(settings_path, "r", encoding="utf-8") as f:
+                settings = json.load(f)
+                default_settings.update(settings)
+        except (json.JSONDecodeError, IOError) as e:
+            logger.warning(f"Could not load settings.json: {e}. Using defaults.")
+    else:
+        logger.info("settings.json not found. Using default settings.")
+
+    return default_settings
+
+
+SETTINGS = load_settings()
+
+
+def run_generate_embeddings():
+    from generate_embeddings import main as gen_main
+    gen_main()
+
+
+def run_query():
+    from query_sniper import main as query_main
+    query_main()
+
+
+def run_inspect():
+    from inspect_graph import main as inspect_main
+    inspect_main()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LLM Extreme Context")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("generate", help="Generate embeddings from call graph")
+    sub.add_parser("query", help="Run interactive query")
+    sub.add_parser("inspect", help="Inspect call graph")
+
+    args = parser.parse_args()
+
+    if args.command == "generate":
+        run_generate_embeddings()
+    elif args.command == "query":
+        run_query()
+    elif args.command == "inspect":
+        run_inspect()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -6,79 +6,54 @@ from pathlib import Path
 from sentence_transformers import SentenceTransformer
 from context_utils import gather_context
 
-# === Settings loader ===
-def load_settings():
-    """Load settings from settings.json with fallback defaults"""
-    default_settings = {
-        "llm_model": "BAAI/bge-small-en",
-        "output_dir": "extracted",
-        "default_project": "ComfyUI",
-        "embedding_dim": 384,
-        "top_k_results": 20,
-        "chunk_size": 1000,
-        "context_hops": 1,
-        "max_neighbors": 5
-    }
-    
-    settings_path = "settings.json"
-    if os.path.exists(settings_path):
-        try:
-            with open(settings_path, "r", encoding="utf-8") as f:
-                settings = json.load(f)
-                default_settings.update(settings)
-        except (json.JSONDecodeError, IOError) as e:
-            print(f"Warning: Could not load settings.json: {e}. Using defaults.")
-    else:
-        print("settings.json not found. Using default settings.")
-    
-    return default_settings
+from Start import SETTINGS
+def main():
+    CALL_GRAPH_PATH = Path(SETTINGS["output_dir"]) / SETTINGS["default_project"] / "call_graph.json"
+    OUTPUT_DIR = Path(SETTINGS["output_dir"]) / SETTINGS["default_project"]
+    EMBEDDING_DIM = SETTINGS["embedding_dim"]
+    MODEL_NAME = SETTINGS["llm_model"]
 
-# Load settings
-SETTINGS = load_settings()
+    print("Loading embedding model...")
+    model_path = SETTINGS.get("local_model_path") or MODEL_NAME
+    model = SentenceTransformer(model_path)
 
-CALL_GRAPH_PATH = Path(SETTINGS["output_dir"]) / SETTINGS["default_project"] / "call_graph.json"
-OUTPUT_DIR = Path(SETTINGS["output_dir"]) / SETTINGS["default_project"]
-EMBEDDING_DIM = SETTINGS["embedding_dim"]
-MODEL_NAME = SETTINGS["llm_model"]
+    print("Loading call graph...")
+    with open(CALL_GRAPH_PATH, "r", encoding="utf-8") as f:
+        graph = json.load(f)
 
-print("Loading embedding model...")
-model = SentenceTransformer(MODEL_NAME)
+    nodes = graph["nodes"]
+    texts = []
+    metadata = []
 
-print("Loading call graph...")
-with open(CALL_GRAPH_PATH, "r", encoding="utf-8") as f:
-    graph = json.load(f)
+    depth = SETTINGS.get("context_hops", 1)
+    limit = SETTINGS.get("max_neighbors", 5)
 
-nodes = graph["nodes"]
-texts = []
-metadata = []
+    print("Encoding function nodes...")
+    for node in nodes:
+        name = node.get("name", "")
+        context = gather_context(graph, node["id"], depth=depth, limit=limit)
+        full_text = f"{name}\n{context}"
+        texts.append(full_text)
+        metadata.append({
+            "id": node["id"],
+            "file": node.get("file_path", ""),
+            "name": name,
+        })
 
-depth = SETTINGS.get("context_hops", 1)
-limit = SETTINGS.get("max_neighbors", 5)
+    print(f"Embedding {len(texts)} nodes...")
+    embeddings = model.encode(texts, normalize_embeddings=True, show_progress_bar=True)
 
-print("Encoding function nodes...")
-for node in nodes:
-    name = node.get("name", "")
-    context = gather_context(graph, node["id"], depth=depth, limit=limit)
-    full_text = f"{name}\n{context}"
-    texts.append(full_text)
-    metadata.append({
-        "id": node["id"],
-        "file": node.get("file_path", ""),
-        "name": name
-    })
+    np.save(OUTPUT_DIR / "embeddings.npy", embeddings)
 
-print(f"Embedding {len(texts)} nodes...")
-embeddings = model.encode(texts, normalize_embeddings=True, show_progress_bar=True)
+    with open(OUTPUT_DIR / "embedding_metadata.json", "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2)
 
-# Save embeddings + metadata
-np.save(OUTPUT_DIR / "embeddings.npy", embeddings)
+    index = faiss.IndexFlatIP(EMBEDDING_DIM)
+    index.add(embeddings.astype(np.float32))
+    faiss.write_index(index, str(OUTPUT_DIR / "faiss.index"))
 
-with open(OUTPUT_DIR / "embedding_metadata.json", "w", encoding="utf-8") as f:
-    json.dump(metadata, f, indent=2)
+    print(f"✅ Saved embeddings and index to {OUTPUT_DIR}")
 
-# Optional: FAISS index
-index = faiss.IndexFlatIP(EMBEDDING_DIM)
-index.add(embeddings.astype(np.float32))
-faiss.write_index(index, str(OUTPUT_DIR / "faiss.index"))
 
-print(f"✅ Saved embeddings and index to {OUTPUT_DIR}")
+if __name__ == "__main__":
+    main()

--- a/inspect_graph.py
+++ b/inspect_graph.py
@@ -5,29 +5,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import networkx as nx
 
-# === Settings loader ===
-def load_settings():
-    """Load settings from settings.json with fallback defaults"""
-    default_settings = {
-        "output_dir": "extracted",
-        "default_project": "ComfyUI"
-    }
-    
-    settings_path = "settings.json"
-    if os.path.exists(settings_path):
-        try:
-            with open(settings_path, "r", encoding="utf-8") as f:
-                settings = json.load(f)
-                default_settings.update(settings)
-        except (json.JSONDecodeError, IOError) as e:
-            print(f"Warning: Could not load settings.json: {e}. Using defaults.")
-    else:
-        print("settings.json not found. Using default settings.")
-    
-    return default_settings
-
-# Load settings
-SETTINGS = load_settings()
+from Start import SETTINGS
 
 def degree_plot(data):
     G = nx.DiGraph()
@@ -71,7 +49,7 @@ def analyze_graph(data):
     for name, count in name_counter.most_common(10):
         print(f"{count:5}  {name}")
 
-if __name__ == "__main__":
+def main():
     extracted_root = Path(SETTINGS["output_dir"])
     if not extracted_root.exists():
         print(f"No '{SETTINGS['output_dir']}/' directory found.")
@@ -100,3 +78,7 @@ if __name__ == "__main__":
 
     data = load_call_graph(call_graph_path)
     analyze_graph(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -6,96 +6,78 @@ import numpy as np
 from sentence_transformers import SentenceTransformer
 from context_utils import expand_neighborhood
 
-# === Settings loader ===
-def load_settings():
-    """Load settings from settings.json with fallback defaults"""
-    default_settings = {
-        "llm_model": "BAAI/bge-small-en",
-        "output_dir": "extracted",
-        "default_project": "ComfyUI",
-        "embedding_dim": 384,
-        "top_k_results": 20,
-        "chunk_size": 1000,
-        "context_hops": 1,
-        "max_neighbors": 5
-    }
-    
-    settings_path = "settings.json"
-    if os.path.exists(settings_path):
-        try:
-            with open(settings_path, "r", encoding="utf-8") as f:
-                settings = json.load(f)
-                default_settings.update(settings)
-        except (json.JSONDecodeError, IOError) as e:
-            print(f"Warning: Could not load settings.json: {e}. Using defaults.")
-    else:
-        print("settings.json not found. Using default settings.")
-    
-    return default_settings
+from Start import SETTINGS
 
-# Load settings
-SETTINGS = load_settings()
 
-# === CONFIG ===
-MODEL_NAME = SETTINGS["llm_model"]
-BASE_DIR = Path(SETTINGS["output_dir"]) / SETTINGS["default_project"]
-EMBEDDINGS_PATH = BASE_DIR / "embeddings.npy"
-METADATA_PATH = BASE_DIR / "embedding_metadata.json"
-INDEX_PATH = BASE_DIR / "faiss.index"
-CALL_GRAPH_PATH = BASE_DIR / "call_graph.json"
+def main():
+    """Interactive search of the generated embeddings."""
+    MODEL_NAME = SETTINGS["llm_model"]
+    BASE_DIR = Path(SETTINGS["output_dir"]) / SETTINGS["default_project"]
+    EMBEDDINGS_PATH = BASE_DIR / "embeddings.npy"
+    METADATA_PATH = BASE_DIR / "embedding_metadata.json"
+    INDEX_PATH = BASE_DIR / "faiss.index"
+    CALL_GRAPH_PATH = BASE_DIR / "call_graph.json"
 
-TOP_K = SETTINGS["top_k_results"]
+    TOP_K = SETTINGS["top_k_results"]
 
-# === INIT ===
-print("🔧 Running... Model, context, and settings info:")
-print(f"Model: {MODEL_NAME}")
-print(f"Context source: {CALL_GRAPH_PATH}")
-print(f"Index file: {INDEX_PATH}")
-print(f"Top-K results: {TOP_K}\n")
+    print("🔧 Running... Model, context, and settings info:")
+    print(f"Model: {MODEL_NAME}")
+    print(f"Context source: {CALL_GRAPH_PATH}")
+    print(f"Index file: {INDEX_PATH}")
+    print(f"Top-K results: {TOP_K}\n")
 
-print("🔄 Loading model and index...")
-model = SentenceTransformer(MODEL_NAME)
-index = faiss.read_index(str(INDEX_PATH))
-with open(METADATA_PATH, "r", encoding="utf-8") as f:
-    metadata = json.load(f)
-with open(CALL_GRAPH_PATH, "r", encoding="utf-8") as f:
-    graph = json.load(f)
-node_map = {n["id"]: n for n in graph.get("nodes", [])}
+    print("🔄 Loading model and index...")
+    model_path = SETTINGS.get("local_model_path") or MODEL_NAME
+    model = SentenceTransformer(model_path)
+    index = faiss.read_index(str(INDEX_PATH))
+    with open(METADATA_PATH, "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+    with open(CALL_GRAPH_PATH, "r", encoding="utf-8") as f:
+        graph = json.load(f)
+    node_map = {n["id"]: n for n in graph.get("nodes", [])}
 
-# === QUERY LOOP ===
-last = None
-while True:
-    query = input("🧠 What is the query? (type 'exit' or 'neighbors <n>')\n> ")
-    if query.strip().lower() in {"exit", "quit"}:
-        print("👋 Exiting.")
-        break
+    last = None
+    while True:
+        query = input("🧠 What is the query? (type 'exit' or 'neighbors <n>')\n> ")
+        if query.strip().lower() in {"exit", "quit"}:
+            print("👋 Exiting.")
+            break
 
-    if query.startswith("neighbors"):
-        if not last:
-            print("No previous search results.")
+        if query.startswith("neighbors"):
+            if not last:
+                print("No previous search results.")
+                continue
+            try:
+                num = int(query.split()[1]) - 1
+                idx = last[num]
+            except Exception:
+                print("Usage: neighbors <result_number>")
+                continue
+            meta = metadata[idx]
+            nb_ids = expand_neighborhood(
+                graph,
+                meta["id"],
+                depth=SETTINGS.get("context_hops", 1),
+                limit=SETTINGS.get("max_neighbors", 5),
+            )
+            print("Neighbors:")
+            for nid in nb_ids:
+                node = node_map.get(nid, {})
+                print(f"- {node.get('name')} — {node.get('file_path')}")
+            print()
             continue
-        try:
-            num = int(query.split()[1]) - 1
-            idx = last[num]
-        except Exception:
-            print("Usage: neighbors <result_number>")
-            continue
-        meta = metadata[idx]
-        nb_ids = expand_neighborhood(graph, meta["id"], depth=SETTINGS.get("context_hops", 1), limit=SETTINGS.get("max_neighbors", 5))
-        print("Neighbors:")
-        for nid in nb_ids:
-            node = node_map.get(nid, {})
-            print(f"- {node.get('name')} — {node.get('file_path')}")
+
+        query_vec = model.encode([query], normalize_embeddings=True)
+        D, I = index.search(np.array(query_vec).astype(np.float32), TOP_K)
+        last = I[0]
+
+        print("\n🎯 Top Matches:")
+        for rank, idx in enumerate(I[0]):
+            meta = metadata[idx]
+            score = D[0][rank]
+            print(f"{rank+1}. {meta['name']} — {meta['file']} (score: {score:.3f})")
         print()
-        continue
 
-    query_vec = model.encode([query], normalize_embeddings=True)
-    D, I = index.search(np.array(query_vec).astype(np.float32), TOP_K)
-    last = I[0]
 
-    print("\n🎯 Top Matches:")
-    for rank, idx in enumerate(I[0]):
-        meta = metadata[idx]
-        score = D[0][rank]
-        print(f"{rank+1}. {meta['name']} — {meta['file']} (score: {score:.3f})")
-    print()
+if __name__ == "__main__":
+    main()

--- a/settings.example.json
+++ b/settings.example.json
@@ -8,6 +8,7 @@
   "chunk_size": 1000,
   "context_hops": 1,
   "max_neighbors": 5,
+  "local_model_path": "",
   "allowed_extensions": [".py", ".js", ".ts", ".json", ".yaml", ".yml", ".md", ".txt", ".html", ".htm"],
   "exclude_dirs": ["__pycache__", ".git", "node_modules", ".venv", "venv", "dist", "build", ".idea", ".vscode", ".pytest_cache"]
 }


### PR DESCRIPTION
## Summary
- add new `Start.py` wrapper with shared settings loader
- update scripts to import settings from `Start.py`
- add optional `local_model_path` setting
- document new entrypoint and setting

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cad16173c832ba84f407c5744ffb7