### PR TITLE
Refactor settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ pytest -q
 
 ### Settings Options
 
-- **llm_model**: The sentence transformer model to use (default: "BAAI/bge-small-en")
-- **output_dir**: Directory where extracted data is stored (default: "extracted")
-- **embedding_dim**: Embedding dimension for the model (default: 384)
-- **top_k_results**: Number of top results to return in queries (default: 20)
-- **chunk_size**: Text chunk size for processing (default: 1000)
-- **allowed_extensions**: File extensions to include in processing
-- **exclude_dirs**: Directories to exclude from processing
-- **local_model_path**: Optional path to a local embedding model
+Settings are grouped into categories for easier navigation:
+
+- **model** – `llm_model`, `local_model_path`
+- **paths** – `output_dir`
+- **embedding** – `embedding_dim`
+- **query** – `top_k_results`
+- **context** – `chunk_size`, `context_hops`, `max_neighbors`
+- **extraction** – `allowed_extensions`, `exclude_dirs`, `comment_lookback_lines`,
+  `token_estimate_ratio`, and `minified_js_detection` options
+- **visualization** – parameters controlling call graph rendering
 
 ### Files
 

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -7,13 +7,13 @@ from context_utils import gather_context
 
 from Start import SETTINGS
 def main(project_folder):
-    CALL_GRAPH_PATH = Path(SETTINGS["output_dir"]) / project_folder / "call_graph.json"
-    OUTPUT_DIR = Path(SETTINGS["output_dir"]) / project_folder
-    EMBEDDING_DIM = SETTINGS["embedding_dim"]
-    MODEL_NAME = SETTINGS["llm_model"]
+    CALL_GRAPH_PATH = Path(SETTINGS["paths"]["output_dir"]) / project_folder / "call_graph.json"
+    OUTPUT_DIR = Path(SETTINGS["paths"]["output_dir"]) / project_folder
+    EMBEDDING_DIM = SETTINGS["embedding"]["embedding_dim"]
+    MODEL_NAME = SETTINGS["model"]["llm_model"]
 
     print("Loading embedding model...")
-    model_path = SETTINGS.get("local_model_path") or MODEL_NAME
+    model_path = SETTINGS.get("model", {}).get("local_model_path") or MODEL_NAME
     model = SentenceTransformer(model_path)
 
     print(f"Loading call graph from {CALL_GRAPH_PATH} ...")
@@ -24,8 +24,8 @@ def main(project_folder):
     texts = []
     metadata = []
 
-    depth = SETTINGS.get("context_hops", 1)
-    limit = SETTINGS.get("max_neighbors", 5)
+    depth = SETTINGS["context"].get("context_hops", 1)
+    limit = SETTINGS["context"].get("max_neighbors", 5)
 
     print("Encoding function nodes...")
     for node in nodes:

--- a/inspect_graph.py
+++ b/inspect_graph.py
@@ -49,7 +49,7 @@ def analyze_graph(data):
         print(f"{count:5}  {name}")
 
 def main(project_folder):
-    extracted_root = Path(SETTINGS["output_dir"])
+    extracted_root = Path(SETTINGS["paths"]["output_dir"])
     selected = extracted_root / project_folder
     call_graph_path = selected / "call_graph.json"
     if not call_graph_path.exists():

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -10,13 +10,13 @@ from Start import SETTINGS
 
 def main(project_folder):
     """Interactive search of the generated embeddings."""
-    MODEL_NAME = SETTINGS["llm_model"]
-    BASE_DIR = Path(SETTINGS["output_dir"]) / project_folder
+    MODEL_NAME = SETTINGS["model"]["llm_model"]
+    BASE_DIR = Path(SETTINGS["paths"]["output_dir"]) / project_folder
     METADATA_PATH = BASE_DIR / "embedding_metadata.json"
     INDEX_PATH = BASE_DIR / "faiss.index"
     CALL_GRAPH_PATH = BASE_DIR / "call_graph.json"
 
-    TOP_K = SETTINGS["top_k_results"]
+    TOP_K = SETTINGS["query"]["top_k_results"]
 
     print("🔧 Running... Model, context, and settings info:")
     print(f"Model: {MODEL_NAME}")
@@ -25,7 +25,7 @@ def main(project_folder):
     print(f"Top-K results: {TOP_K}\n")
 
     print("🔄 Loading model and index...")
-    model_path = SETTINGS.get("local_model_path") or MODEL_NAME
+    model_path = SETTINGS.get("model", {}).get("local_model_path") or MODEL_NAME
     model = SentenceTransformer(model_path)
     index = faiss.read_index(str(INDEX_PATH))
     with open(METADATA_PATH, "r", encoding="utf-8") as f:
@@ -55,8 +55,8 @@ def main(project_folder):
             nb_ids = expand_neighborhood(
                 graph,
                 meta["id"],
-                depth=SETTINGS.get("context_hops", 1),
-                limit=SETTINGS.get("max_neighbors", 5),
+                depth=SETTINGS["context"].get("context_hops", 1),
+                limit=SETTINGS["context"].get("max_neighbors", 5),
             )
             print("Neighbors:")
             for nid in nb_ids:

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,13 +1,65 @@
 {
   "_comment": "Copy this file to settings.json and modify as needed",
-  "llm_model": "BAAI/bge-small-en",
-  "output_dir": "extracted",
-  "local_model_path": "",
-  "embedding_dim": 384,
-  "top_k_results": 20,
-  "chunk_size": 1000,
-  "context_hops": 1,
-  "max_neighbors": 5,
-  "allowed_extensions": [".py", ".js", ".ts", ".json", ".yaml", ".yml", ".md", ".txt", ".html", ".htm"],
-  "exclude_dirs": ["__pycache__", ".git", "node_modules", ".venv", "venv", "dist", "build", ".idea", ".vscode", ".pytest_cache"]
+  "model": {
+    "llm_model": "BAAI/bge-small-en",
+    "local_model_path": ""
+  },
+  "paths": {
+    "output_dir": "extracted"
+  },
+  "embedding": {
+    "embedding_dim": 384
+  },
+  "query": {
+    "top_k_results": 20
+  },
+  "context": {
+    "chunk_size": 1000,
+    "context_hops": 1,
+    "max_neighbors": 5
+  },
+  "extraction": {
+    "allowed_extensions": [
+      ".py",
+      ".js",
+      ".ts",
+      ".json",
+      ".yaml",
+      ".yml",
+      ".md",
+      ".txt",
+      ".html",
+      ".htm"
+    ],
+    "exclude_dirs": [
+      "__pycache__",
+      ".git",
+      "node_modules",
+      ".venv",
+      "venv",
+      "dist",
+      "build",
+      ".idea",
+      ".vscode",
+      ".pytest_cache"
+    ],
+    "comment_lookback_lines": 3,
+    "token_estimate_ratio": 0.75,
+    "minified_js_detection": {
+      "max_lines_to_check": 50,
+      "single_line_threshold": 2000,
+      "required_long_lines": 2
+    }
+  },
+  "visualization": {
+    "figsize": [
+      12,
+      10
+    ],
+    "spring_layout_k": 0.5,
+    "spring_layout_iterations": 20,
+    "node_size": 1500,
+    "font_size": 8,
+    "node_color": "skyblue"
+  }
 }


### PR DESCRIPTION
## Summary
- organize settings into categories
- control JS minification and visualization constants with settings
- use settings for comment lookback and token estimate
- update utilities to new nested settings layout
- document setting categories in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce3b1c58c832bad7dbfdf59c9367f