### PR TITLE
Add bidirectional call graph expansion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,14 @@ those embeddings. The main scripts are located in the repository root.
    list of entries. `build_call_graph` then creates a `networkx` graph from
    these entries and `save_graph_json` writes it to disk.
 2. **Context Gathering** – `context_utils.gather_context` uses
-   `expand_neighborhood` to collect code from surrounding nodes in a graph.
+   `expand_graph` to collect code from surrounding nodes in a graph. Direction
+   can be controlled with the `bidirectional` setting.
 3. **Embedding Generation** – `generate_embeddings.main` loads the call graph,
    gathers context for each node, encodes the text with
    `SentenceTransformer`, and saves a FAISS index.
 4. **Querying** – `query_sniper.main` loads the embeddings and lets users run
    similarity searches. It can also show neighbors using
-   `expand_neighborhood`.
+   `expand_graph`.
 5. **Inspection** – `inspect_graph.main` analyzes the call graph (e.g., node
    degree) and can plot distributions.
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ Settings are grouped into categories for easier navigation:
 - **paths** – `output_dir`
 - **embedding** – `embedding_dim`
 - **query** – `top_k_results`
-- **context** – `chunk_size`, `context_hops`, `max_neighbors`
+- **context** – `chunk_size`, `context_hops`, `max_neighbors`, `bidirectional`
 - **extraction** – `allowed_extensions`, `exclude_dirs`, `comment_lookback_lines`,
   `token_estimate_ratio`, and `minified_js_detection` options
 - **visualization** – parameters controlling call graph rendering
+
+When `bidirectional` is `True`, context expansion walks both callers and
+callees. Set it to `False` to only follow outgoing calls.
 
 ### Files
 

--- a/Start.py
+++ b/Start.py
@@ -23,6 +23,7 @@ DEFAULT_SETTINGS = {
         "chunk_size": 1000,
         "context_hops": 1,
         "max_neighbors": 5,
+        "bidirectional": True,
     },
     "extraction": {
         "allowed_extensions": [

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -26,11 +26,14 @@ def main(project_folder):
 
     depth = SETTINGS["context"].get("context_hops", 1)
     limit = SETTINGS["context"].get("max_neighbors", 5)
+    bidir = SETTINGS["context"].get("bidirectional", True)
 
     print("Encoding function nodes...")
     for node in nodes:
         name = node.get("name", "")
-        context = gather_context(graph, node["id"], depth=depth, limit=limit)
+        context = gather_context(
+            graph, node["id"], depth=depth, limit=limit, bidirectional=bidir
+        )
         full_text = f"{name}\n{context}"
         texts.append(full_text)
         metadata.append({

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import faiss
 import numpy as np
 from sentence_transformers import SentenceTransformer
-from context_utils import expand_neighborhood
+from context_utils import expand_graph
 
 from Start import SETTINGS
 
@@ -52,11 +52,12 @@ def main(project_folder):
                 print("Usage: neighbors <result_number>")
                 continue
             meta = metadata[idx]
-            nb_ids = expand_neighborhood(
+            nb_ids = expand_graph(
                 graph,
                 meta["id"],
                 depth=SETTINGS["context"].get("context_hops", 1),
                 limit=SETTINGS["context"].get("max_neighbors", 5),
+                bidirectional=SETTINGS["context"].get("bidirectional", True),
             )
             print("Neighbors:")
             for nid in nb_ids:

--- a/settings.example.json
+++ b/settings.example.json
@@ -16,7 +16,8 @@
   "context": {
     "chunk_size": 1000,
     "context_hops": 1,
-    "max_neighbors": 5
+    "max_neighbors": 5,
+    "bidirectional": true
   },
   "extraction": {
     "allowed_extensions": [

--- a/tests/test_expand_graph.py
+++ b/tests/test_expand_graph.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import context_utils as cu
+
+SIMPLE_GRAPH = {
+    "nodes": [
+        {"id": "A"},
+        {"id": "B"},
+        {"id": "C"},
+    ],
+    "edges": [
+        {"from": "A", "to": "B"},
+        {"from": "B", "to": "C"},
+    ],
+}
+
+def test_expand_graph_directional():
+    res = cu.expand_graph(SIMPLE_GRAPH, "B", depth=1, bidirectional=False)
+    assert res == ["C"]
+    res = cu.expand_graph(SIMPLE_GRAPH, "C", depth=1, bidirectional=False)
+    assert res == []
+
+
+def test_expand_graph_bidirectional():
+    res = set(cu.expand_graph(SIMPLE_GRAPH, "B", depth=1, bidirectional=True))
+    assert res == {"A", "C"}
+
+


### PR DESCRIPTION
## Summary
- add `expand_graph` with `bidirectional` flag and refactor `gather_context`
- update CLI to use the new expansion method
- expose `bidirectional` setting in defaults and example settings
- document the new option in `README.md` and `AGENTS.md`
- add unit tests for bidirectional expansion

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce7df241c832b92f227f4101e9505