### PR TITLE
Enhance call graph analysis with weighting and import resolution

### DIFF
--- a/Start.py
+++ b/Start.py
@@ -24,6 +24,8 @@ DEFAULT_SETTINGS = {
         "context_hops": 1,
         "max_neighbors": 5,
         "bidirectional": True,
+        "outbound_weight": 1.0,
+        "inbound_weight": 1.0,
     },
     "extraction": {
         "allowed_extensions": [

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -27,12 +27,20 @@ def main(project_folder):
     depth = SETTINGS["context"].get("context_hops", 1)
     limit = SETTINGS["context"].get("max_neighbors", 5)
     bidir = SETTINGS["context"].get("bidirectional", True)
+    out_w = SETTINGS["context"].get("outbound_weight", 1.0)
+    in_w = SETTINGS["context"].get("inbound_weight", 1.0)
 
     print("Encoding function nodes...")
     for node in nodes:
         name = node.get("name", "")
         context = gather_context(
-            graph, node["id"], depth=depth, limit=limit, bidirectional=bidir
+            graph,
+            node["id"],
+            depth=depth,
+            limit=limit,
+            bidirectional=bidir,
+            outbound_weight=out_w,
+            inbound_weight=in_w,
         )
         full_text = f"{name}\n{context}"
         texts.append(full_text)

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -58,6 +58,8 @@ def main(project_folder):
                 depth=SETTINGS["context"].get("context_hops", 1),
                 limit=SETTINGS["context"].get("max_neighbors", 5),
                 bidirectional=SETTINGS["context"].get("bidirectional", True),
+                outbound_weight=SETTINGS["context"].get("outbound_weight", 1.0),
+                inbound_weight=SETTINGS["context"].get("inbound_weight", 1.0),
             )
             print("Neighbors:")
             for nid in nb_ids:

--- a/settings.example.json
+++ b/settings.example.json
@@ -17,7 +17,9 @@
     "chunk_size": 1000,
     "context_hops": 1,
     "max_neighbors": 5,
-    "bidirectional": true
+    "bidirectional": true,
+    "outbound_weight": 1.0,
+    "inbound_weight": 1.0
   },
   "extraction": {
     "allowed_extensions": [

--- a/tests/test_expand_graph.py
+++ b/tests/test_expand_graph.py
@@ -29,3 +29,26 @@ def test_expand_graph_bidirectional():
     assert res == {"A", "C"}
 
 
+def test_expand_graph_weighted():
+    graph = {
+        "nodes": [
+            {"id": "A"},
+            {"id": "B"},
+            {"id": "C"},
+        ],
+        "edges": [
+            {"from": "A", "to": "B", "weight": 2},
+            {"from": "B", "to": "C", "weight": 1},
+        ],
+    }
+    res = cu.expand_graph(
+        graph,
+        "A",
+        depth=2,
+        bidirectional=False,
+        outbound_weight=2,
+        inbound_weight=1,
+    )
+    assert res == ["B", "C"]
+
+


### PR DESCRIPTION
## Summary
- capture attribute-based method calls
- map imports and add edge weights when building call graph
- expose directional weighting for graph expansion
- persist edge weights in call graph json
- pass weighting settings through embedding and query tools
- update default settings and examples
- test expanded extraction, graph building, import linking, weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ceb741178832baeaa81ad9a492462