### PR TITLE
Support JSON/YAML/txt extraction

### DIFF
--- a/Start.py
+++ b/Start.py
@@ -159,6 +159,9 @@ def run_extract(project_path: Path, project_name: str):
         extract_from_html,
         extract_from_markdown,
         extract_from_javascript,
+        extract_from_json,
+        extract_from_yaml,
+        extract_from_txt,
         build_call_graph,
         save_graph_json,
     )
@@ -179,6 +182,12 @@ def run_extract(project_path: Path, project_name: str):
                 entries.extend(extract_from_html(str(fpath)))
             elif ext in {".md", ".markdown"}:
                 entries.extend(extract_from_markdown(str(fpath)))
+            elif ext == ".json":
+                entries.extend(extract_from_json(str(fpath)))
+            elif ext in {".yaml", ".yml"}:
+                entries.extend(extract_from_yaml(str(fpath)))
+            elif ext == ".txt":
+                entries.extend(extract_from_txt(str(fpath)))
 
     graph = build_call_graph(entries)
     out_dir = Path(SETTINGS["paths"]["output_dir"]) / project_name

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -127,3 +127,46 @@ def bar():
     bar_id = f"{f}::bar"
     foo_id = f"{f}::foo"
     assert graph[bar_id][foo_id]["weight"] == 2
+
+
+def test_extract_from_json(tmp_path):
+    data = {"a": 1, "b": {"c": 2}}
+    f = tmp_path / "config.json"
+    f.write_text(json.dumps(data))
+    results = lec.extract_from_json(str(f))
+    assert results
+    entry = results[0]
+    assert entry["language"] == "json"
+    assert "a" in entry["code"]
+
+
+def test_extract_from_yaml(tmp_path):
+    text = "a: 1\nb:\n  c: 2\n"
+    f = tmp_path / "config.yaml"
+    f.write_text(text)
+    results = lec.extract_from_yaml(str(f))
+    assert results
+    entry = results[0]
+    assert entry["language"] == "yaml"
+    assert '"a"' in entry["code"]
+
+
+def test_extract_from_txt(tmp_path):
+    content = "hello world"
+    f = tmp_path / "notes.txt"
+    f.write_text(content)
+    results = lec.extract_from_txt(str(f))
+    assert results == [
+        {
+            "file_path": str(f),
+            "language": "text",
+            "type": "raw_text",
+            "name": None,
+            "code": content,
+            "comments": [],
+            "called_functions": [],
+            "hash": lec.hash_content(content),
+            "estimated_tokens": lec.estimate_tokens(content),
+        }
+    ]
+


### PR DESCRIPTION
## Summary
- wire JSON/YAML/text extractors into `run_extract`
- test new extractors for config and txt files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf4a91284832ba7be7c3d371d76ca