### PR TITLE
Use crawl_directory in Start.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Settings are grouped into categories for easier navigation:
   `token_estimate_ratio`, and `minified_js_detection` options
 - **visualization** – parameters controlling call graph rendering
 
+The extraction step relies on `crawl_directory` which automatically skips files
+listed in `.gitignore` and only processes paths with extensions from
+`allowed_extensions`.
+
 When `bidirectional` is `True`, context expansion walks both callers and
 callees. Set it to `False` to only follow outgoing calls.
 

--- a/Start.py
+++ b/Start.py
@@ -155,30 +155,12 @@ SETTINGS = load_settings()
 def run_extract(project_path: Path, project_name: str):
     """Extract functions from the project and build the call graph."""
     from LLM_Extreme_Context import (
-        extract_from_python,
-        extract_from_html,
-        extract_from_markdown,
-        extract_from_javascript,
+        crawl_directory,
         build_call_graph,
         save_graph_json,
     )
 
-    entries = []
-    for root, dirs, files in os.walk(project_path):
-        dirs[:] = [d for d in dirs if d not in SETTINGS["extraction"]["exclude_dirs"]]
-        for fname in files:
-            ext = Path(fname).suffix.lower()
-            if ext not in SETTINGS["extraction"]["allowed_extensions"]:
-                continue
-            fpath = Path(root) / fname
-            if ext == ".py":
-                entries.extend(extract_from_python(str(fpath)))
-            elif ext in {".js", ".ts"}:
-                entries.extend(extract_from_javascript(str(fpath)))
-            elif ext in {".html", ".htm"}:
-                entries.extend(extract_from_html(str(fpath)))
-            elif ext in {".md", ".markdown"}:
-                entries.extend(extract_from_markdown(str(fpath)))
+    entries = crawl_directory(str(project_path), respect_gitignore=True)
 
     graph = build_call_graph(entries)
     out_dir = Path(SETTINGS["paths"]["output_dir"]) / project_name

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -127,3 +127,17 @@ def bar():
     bar_id = f"{f}::bar"
     foo_id = f"{f}::foo"
     assert graph[bar_id][foo_id]["weight"] == 2
+
+
+def test_crawl_directory_extensions_and_gitignore(tmp_path):
+    (tmp_path / "a.py").write_text("def foo():\n    pass\n")
+    (tmp_path / "config.json").write_text("{\"a\": 1}")
+    (tmp_path / "README.md").write_text("# hi")
+    (tmp_path / "ignore.yml").write_text("a: b")
+    (tmp_path / ".gitignore").write_text("ignore.yml\n")
+
+    entries = lec.crawl_directory(str(tmp_path))
+    processed = {Path(e["file_path"]).name for e in entries}
+
+    assert {"a.py", "config.json", "README.md"} <= processed
+    assert "ignore.yml" not in processed


### PR DESCRIPTION
## Summary
- delegate extraction to `crawl_directory` which honors `.gitignore`
- document the new behavior
- test that crawl_directory respects allowed extensions and gitignore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf5295768832bb85620714f490739