### PR TITLE
Add spellcheck and query rephrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
+The first query run will download the T5 paraphrasing model if
+`rephrase_count` is greater than 1. Provide `rephrase_model_path`
+in `settings.json` to use a local checkpoint instead.
+
 Run the tests with `pytest` to ensure everything works:
 
 ```bash
@@ -30,7 +34,8 @@ Settings are grouped into categories for easier navigation:
 - **model** – `llm_model`, `local_model_path`
 - **paths** – `output_dir`
 - **embedding** – `embedding_dim`
-- **query** – `top_k_results`
+- **query** – `top_k_results`, `use_spellcheck`, `rephrase_count`,
+  `rephrase_model_path`
 - **context** – `chunk_size`, `context_hops`, `max_neighbors`, `bidirectional`
 - **extraction** – `allowed_extensions`, `exclude_dirs`, `comment_lookback_lines`,
   `token_estimate_ratio`, and `minified_js_detection` options
@@ -58,3 +63,19 @@ callees. Set it to `False` to only follow outgoing calls.
 The `settings.json` file is automatically loaded by all scripts. If the file doesn't exist, it will be generated with defaults the first time you run the tools.
 Run `python Start.py [path]` where `path` is the folder you want to analyse. If the artifacts for that project do not exist they will be created and you will then be dropped into the interactive query interface.
 While in the query interface you can type `neighbors <n>` to see the graph neighbors of result `n` from the previous search.
+
+### Spellcheck and Query Rephrasing
+
+Two optional features help refine search queries:
+
+- **use_spellcheck** – when `true`, the query is corrected using SymSpell before searching.
+  A small dictionary is built from function names automatically, but you can also
+  download a larger frequency dictionary from the SymSpell repository and place it
+  in the project root.
+- **rephrase_count** – if greater than 1, a T5 paraphrasing model generates additional
+  variants of the query. All variations are embedded and averaged together before
+  the FAISS search.
+  If you have a local checkpoint, set `rephrase_model_path` to avoid downloading.
+
+Enable these options in `settings.json` under the `query` section. The `transformers`
+package will download the paraphrasing model the first time it is used.

--- a/Start.py
+++ b/Start.py
@@ -18,7 +18,12 @@ DEFAULT_SETTINGS = {
         "output_dir": "extracted",
     },
     "embedding": {"embedding_dim": 384},
-    "query": {"top_k_results": 20},
+    "query": {
+        "top_k_results": 20,
+        "use_spellcheck": False,
+        "rephrase_count": 1,
+        "rephrase_model_path": "",
+    },
     "context": {
         "chunk_size": 1000,
         "context_hops": 1,
@@ -88,7 +93,7 @@ def ensure_example_settings():
 
     if current != template:
         with open(example_path, "w", encoding="utf-8") as f:
-            json.dump(template, f, indent=2)
+            json.dump(template, f, indent=2, sort_keys=True)
 
 
 def load_settings():

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ faiss-cpu
 numpy
 pyyaml
 pathspec
+symspellpy
+transformers

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,25 +1,15 @@
 {
   "_comment": "Copy this file to settings.json and modify as needed",
-  "model": {
-    "llm_model": "BAAI/bge-small-en",
-    "local_model_path": ""
-  },
-  "paths": {
-    "output_dir": "extracted"
+  "context": {
+    "bidirectional": true,
+    "chunk_size": 1000,
+    "context_hops": 1,
+    "inbound_weight": 1.0,
+    "max_neighbors": 5,
+    "outbound_weight": 1.0
   },
   "embedding": {
     "embedding_dim": 384
-  },
-  "query": {
-    "top_k_results": 20
-  },
-  "context": {
-    "chunk_size": 1000,
-    "context_hops": 1,
-    "max_neighbors": 5,
-    "bidirectional": true,
-    "outbound_weight": 1.0,
-    "inbound_weight": 1.0
   },
   "extraction": {
     "allowed_extensions": [
@@ -34,6 +24,7 @@
       ".html",
       ".htm"
     ],
+    "comment_lookback_lines": 3,
     "exclude_dirs": [
       "__pycache__",
       ".git",
@@ -46,23 +37,35 @@
       ".vscode",
       ".pytest_cache"
     ],
-    "comment_lookback_lines": 3,
-    "token_estimate_ratio": 0.75,
     "minified_js_detection": {
       "max_lines_to_check": 50,
-      "single_line_threshold": 2000,
-      "required_long_lines": 2
-    }
+      "required_long_lines": 2,
+      "single_line_threshold": 2000
+    },
+    "token_estimate_ratio": 0.75
+  },
+  "model": {
+    "llm_model": "BAAI/bge-small-en",
+    "local_model_path": ""
+  },
+  "paths": {
+    "output_dir": "extracted"
+  },
+  "query": {
+    "rephrase_count": 1,
+    "rephrase_model_path": "",
+    "top_k_results": 20,
+    "use_spellcheck": false
   },
   "visualization": {
     "figsize": [
       12,
       10
     ],
-    "spring_layout_k": 0.5,
-    "spring_layout_iterations": 20,
-    "node_size": 1500,
     "font_size": 8,
-    "node_color": "skyblue"
+    "node_color": "skyblue",
+    "node_size": 1500,
+    "spring_layout_iterations": 20,
+    "spring_layout_k": 0.5
   }
 }

--- a/tests/test_query_features.py
+++ b/tests/test_query_features.py
@@ -1,0 +1,31 @@
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from Start import DEFAULT_SETTINGS
+from query_sniper import build_symspell, correct_query, average_embeddings
+
+
+def test_default_query_settings():
+    q = DEFAULT_SETTINGS["query"]
+    assert q["use_spellcheck"] is False
+    assert q["rephrase_count"] == 1
+    assert q["rephrase_model_path"] == ""
+
+
+def test_spellcheck_basic():
+    metadata = [{"name": "foobar"}]
+    sym = build_symspell(metadata)
+    corrected = correct_query(sym, "foobzr")
+    assert corrected == "foobar"
+
+
+def test_average_embeddings():
+    class Dummy:
+        def encode(self, texts, normalize_embeddings=True):
+            return np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    vec = average_embeddings(Dummy(), ["a", "b"])
+    assert np.allclose(vec, [[2.0, 3.0]])


### PR DESCRIPTION
## Summary
- support `use_spellcheck` and `rephrase_count` settings
- create helper functions in `query_sniper` for spellcheck and averaging
- update settings example and requirements
- document spellcheck and paraphrasing usage
- test default settings, spellcheck and averaging logic
- allow `rephrase_model_path` setting to load local paraphrase model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d059bf714832b8cd530e5019819ac