### PR TITLE
Fix configuration sync and cleanup unused setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 # Ignore settings file to prevent tracking local configurations
 # Use settings.example.json as a template to create your settings.json
 settings.json
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Settings are grouped into categories for easier navigation:
 - **embedding** – `embedding_dim`
 - **query** – `top_k_results`, `use_spellcheck`, `rephrase_count`,
   `rephrase_model_path`
-- **context** – `chunk_size`, `context_hops`, `max_neighbors`, `bidirectional`
+- **context** – `context_hops`, `max_neighbors`, `bidirectional`
 - **extraction** – `allowed_extensions`, `exclude_dirs`, `comment_lookback_lines`,
   `token_estimate_ratio`, and `minified_js_detection` options
 - **visualization** – parameters controlling call graph rendering

--- a/Start.py
+++ b/Start.py
@@ -25,7 +25,6 @@ DEFAULT_SETTINGS = {
         "rephrase_model_path": "",
     },
     "context": {
-        "chunk_size": 1000,
         "context_hops": 1,
         "max_neighbors": 5,
         "bidirectional": True,
@@ -94,6 +93,7 @@ def ensure_example_settings():
     if current != template:
         with open(example_path, "w", encoding="utf-8") as f:
             json.dump(template, f, indent=2, sort_keys=True)
+            f.write("\n")
 
 
 def load_settings():

--- a/settings.example.json
+++ b/settings.example.json
@@ -2,7 +2,6 @@
   "_comment": "Copy this file to settings.json and modify as needed",
   "context": {
     "bidirectional": true,
-    "chunk_size": 1000,
     "context_hops": 1,
     "inbound_weight": 1.0,
     "max_neighbors": 5,

--- a/tests/test_settings_sync.py
+++ b/tests/test_settings_sync.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from Start import DEFAULT_SETTINGS, ensure_example_settings
+
+
+def test_settings_example_matches_defaults(tmp_path, monkeypatch):
+    example = tmp_path / "settings.example.json"
+    monkeypatch.chdir(tmp_path)
+    ensure_example_settings()
+    data = json.loads(example.read_text())
+    assert data == {"_comment": "Copy this file to settings.json and modify as needed", **DEFAULT_SETTINGS}
+


### PR DESCRIPTION
## Summary
- drop unused `chunk_size` setting and docs
- ensure `settings.example.json` is always synced and newline-terminated
- ignore pytest cache
- add test covering settings example sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d14619e1c832bb0b778c85ec8a1fd