### PR TITLE
Add prompt builder workflow and relative path display

### DIFF
--- a/Start.py
+++ b/Start.py
@@ -17,6 +17,7 @@ DEFAULT_SETTINGS = {
     "paths": {
         "output_dir": "extracted",
     },
+    "api_key": "",
     "embedding": {"embedding_dim": 384},
     "query": {
         "top_k_results": 20,
@@ -201,6 +202,7 @@ def main():
 
     project_name = project_path.name
     SETTINGS["default_project"] = project_name
+    SETTINGS["project_root"] = str(project_path.resolve())
 
     out_dir = Path(SETTINGS["paths"]["output_dir"]) / project_name
     call_graph_path = out_dir / "call_graph.json"

--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -3,7 +3,7 @@ import json
 from summary_formatter import _truncate_code
 
 
-def build_prompt(metadata_path, graph_path, indices, user_question):
+def build_prompt(metadata_path, graph_path, indices, user_question, base_dir=None, save_path=None):
     """
     Given FAISS result indices, metadata, and call graph, format a Gemini-ready prompt.
     """
@@ -14,6 +14,7 @@ def build_prompt(metadata_path, graph_path, indices, user_question):
 
     node_map = {n["id"]: n for n in graph.get("nodes", [])}
     blocks = ["# QUESTION", user_question.strip(), "", f"# FUNCTION CONTEXT (Top {len(indices)} Matches)"]
+    blocks_full = ["# QUESTION", user_question.strip(), "", f"# FUNCTION CONTEXT (Top {len(indices)} Matches)"]
 
     for i, idx in enumerate(indices):
         meta = metadata[idx]
@@ -21,6 +22,12 @@ def build_prompt(metadata_path, graph_path, indices, user_question):
 
         name = node.get("name", meta.get("name", "unknown"))
         file_path = node.get("file_path", meta.get("file", "unknown"))
+        display_path = file_path
+        if base_dir:
+            try:
+                display_path = str(Path(file_path).resolve().relative_to(Path(base_dir).resolve()))
+            except Exception:
+                pass
         comments = node.get("comments", [])[:5]
         calls = [node_map.get(cid, {}).get("name", cid) for cid in node.get("calls", [])]
         called_by = [node_map.get(cid, {}).get("name", cid) for cid in node.get("called_by", [])]
@@ -30,7 +37,7 @@ def build_prompt(metadata_path, graph_path, indices, user_question):
             f"## Function {i + 1}",
             f"ID: {meta['id']}",
             f"Name: {name}",
-            f"File: {file_path}",
+            f"File: {display_path}",
             f"Comments:",
         ]
         section += [f"- {c}" for c in comments] if comments else ["- None"]
@@ -45,7 +52,29 @@ def build_prompt(metadata_path, graph_path, indices, user_question):
 
         blocks.append("\n".join(section))
 
-    return "\n\n".join(blocks)
+        full_section = [
+            f"## Function {i + 1}",
+            f"ID: {meta['id']}",
+            f"Name: {name}",
+            f"File: {file_path}",
+            f"Comments:",
+        ]
+        full_section += [f"- {c}" for c in comments] if comments else ["- None"]
+        full_section.append("Calls:")
+        full_section += [f"- {c}" for c in calls] if calls else ["- None"]
+        full_section.append("Called By:")
+        full_section += [f"- {c}" for c in called_by] if called_by else ["- None"]
+        full_section.append("Code:")
+        full_section.append("```python")
+        full_section.append(code)
+        full_section.append("```")
+
+        blocks_full.append("\n".join(full_section))
+
+    result = "\n\n".join(blocks)
+    if save_path:
+        Path(save_path).write_text("\n\n".join(blocks_full), encoding="utf-8")
+    return result
 
 
 # Example usage

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -7,6 +7,7 @@ from symspellpy import SymSpell, Verbosity
 from transformers.pipelines import pipeline
 from context_utils import expand_graph
 from summary_formatter import format_summary
+from prompt_builder import build_prompt
 
 from Start import SETTINGS
 
@@ -121,9 +122,32 @@ def main(project_folder):
         last = indices[0]
 
         print("\n🎯 Top Matches:")
-        summary = format_summary(indices[0], metadata, node_map)
+        summary = format_summary(
+            indices[0],
+            metadata,
+            node_map,
+            save_path=str(BASE_DIR / "last_summary.txt"),
+            base_dir=SETTINGS.get("project_root"),
+        )
         print(summary)
         print()
+
+        follow = input("What problem are you trying to solve?\n> ").strip()
+        prompt_text = build_prompt(
+            METADATA_PATH,
+            CALL_GRAPH_PATH,
+            [int(i) for i in indices[0]],
+            follow,
+            base_dir=SETTINGS.get("project_root"),
+            save_path=str(BASE_DIR / "initial_prompt.txt"),
+        )
+        print("\nGenerated initial prompt:\n")
+        print(prompt_text)
+        print()
+        if not SETTINGS.get("api_key"):
+            print("No API key found in settings.json under 'api_key'. Provide one to automatically query an LLM.")
+        else:
+            print("Use the above prompt with your configured API key.")
 
 
 if __name__ == "__main__":

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Copy this file to settings.json and modify as needed",
+  "api_key": "",
   "context": {
     "bidirectional": true,
     "context_hops": 1,

--- a/summary_formatter.py
+++ b/summary_formatter.py
@@ -1,5 +1,6 @@
 # Utilities to format search results as function summaries
 from typing import Iterable, Dict, Any, Optional
+from pathlib import Path
 
 
 def _truncate_code(code: str, max_lines: int = 40) -> str:
@@ -18,6 +19,7 @@ def format_summary(
     node_map: Dict[str, Dict[str, Any]],
     *,
     save_path: Optional[str] = None,
+    base_dir: Optional[str] = None,
 ) -> str:
     """Generate summary text for given result indices and metadata.
 
@@ -34,12 +36,19 @@ def format_summary(
         If provided, write the output to this file.
     """
     blocks: list[str] = []
+    blocks_full: list[str] = []
     for idx in indices:
         meta = metadata[idx]
         node = node_map.get(meta.get("id"), {})
 
         name = node.get("name", meta.get("name"))
         file_path = node.get("file_path", meta.get("file"))
+        display_path = file_path
+        if base_dir:
+            try:
+                display_path = str(Path(file_path).resolve().relative_to(Path(base_dir).resolve()))
+            except Exception:
+                pass
         lang = node.get("language", "unknown")
         tokens = node.get("estimated_tokens", 0)
 
@@ -51,7 +60,7 @@ def format_summary(
         block_lines = [
             "=" * 40,
             f"Function: {name}",
-            f"File: {file_path}",
+            f"File: {display_path}",
             f"Language: {lang}",
             f"Estimated Tokens: {tokens}",
             "",
@@ -82,8 +91,40 @@ def format_summary(
         block_lines.append("=" * 40)
         blocks.append("\n".join(block_lines))
 
+        # Full-path version for saving
+        block_full = [
+            "=" * 40,
+            f"Function: {name}",
+            f"File: {file_path}",
+            f"Language: {lang}",
+            f"Estimated Tokens: {tokens}",
+            "",
+            "Comments:",
+        ]
+        for c in comments:
+            block_full.append(f"  - {c}")
+        if not comments:
+            block_full.append("  - None")
+        block_full.append("")
+        block_full.append("Calls:")
+        for c in calls:
+            block_full.append(f"  - {c}")
+        if not calls:
+            block_full.append("  - None")
+        block_full.append("")
+        block_full.append("Called By:")
+        for c in called_by:
+            block_full.append(f"  - {c}")
+        if not called_by:
+            block_full.append("  - None")
+        block_full.append("")
+        block_full.append("Code:")
+        block_full.append(code)
+        block_full.append("=" * 40)
+        blocks_full.append("\n".join(block_full))
+
     output = "\n".join(blocks)
     if save_path:
         with open(save_path, "w", encoding="utf-8") as f:
-            f.write(output)
+            f.write("\n".join(blocks_full))
     return output


### PR DESCRIPTION
## Summary
- add `api_key` to settings and track project root path
- adjust `summary_formatter` and `prompt_builder` to accept a base directory and save full paths to file
- integrate prompt building into `query_sniper` with follow-up question and instructions
- write example settings with new key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d355d8c80832b8b5fdd9302ff3978