### PR TITLE
Refactor LLM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ pytest -q
 
 ### Settings Options
 
-Settings are grouped into categories for easier navigation:
+- Settings are grouped into categories for easier navigation:
 
-- **model** – `llm_model`, `local_model_path`
+- **LLM_model** – `api_key`, `api_type`, `local_path`
+- **encoder_model_path** – location of the sentence transformer model
 - **paths** – `output_dir`
 - **embedding** – `embedding_dim`
 - **query** – `top_k_results`, `use_spellcheck`, `rephrase_count`,

--- a/Start.py
+++ b/Start.py
@@ -10,14 +10,14 @@ logger = logging.getLogger(__name__)
 
 # Default configuration used by all tools
 DEFAULT_SETTINGS = {
-    "model": {
-        "llm_model": "BAAI/bge-small-en",  # example local model
-        "local_model_path": "",
+    "LLM_model": {
+        "api_key": "",
+        "api_type": "gemini",
+        "local_path": "",
     },
     "paths": {
         "output_dir": "extracted",
     },
-    "api_key": "",
     "embedding": {"embedding_dim": 384},
     "query": {
         "top_k_results": 20,
@@ -73,6 +73,7 @@ DEFAULT_SETTINGS = {
         "font_size": 8,
         "node_color": "skyblue",
     },
+    "encoder_model_path": "",
 }
 
 
@@ -93,7 +94,7 @@ def ensure_example_settings():
 
     if current != template:
         with open(example_path, "w", encoding="utf-8") as f:
-            json.dump(template, f, indent=2, sort_keys=True)
+            json.dump(template, f, indent=2)
             f.write("\n")
         logger.info("Updated %s with default settings", example_path)
 

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -11,10 +11,11 @@ def main(project_folder):
     CALL_GRAPH_PATH = Path(SETTINGS["paths"]["output_dir"]) / project_folder / "call_graph.json"
     OUTPUT_DIR = Path(SETTINGS["paths"]["output_dir"]) / project_folder
     EMBEDDING_DIM = SETTINGS["embedding"]["embedding_dim"]
-    MODEL_NAME = SETTINGS["model"]["llm_model"]
+    model_path = SETTINGS.get("encoder_model_path")
 
     print("Loading embedding model...")
-    model_path = SETTINGS.get("model", {}).get("local_model_path") or MODEL_NAME
+    if not model_path:
+        raise ValueError("encoder_model_path is not set in settings.json")
     model = SentenceTransformer(model_path)
 
     print(f"Loading call graph from {CALL_GRAPH_PATH} ...")

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,0 +1,40 @@
+import google.generativeai as genai
+from Start import SETTINGS
+
+# Only Gemini is supported right now
+
+def get_llm_model():
+    """Load the LLM model based on settings. Defaults to the Gemini API."""
+    cfg = SETTINGS.get("LLM_model", {})
+    api_key = cfg.get("api_key", "")
+    api_type = cfg.get("api_type", "gemini").lower()
+    local_path = cfg.get("local_path", "")
+
+    if api_key:
+        if api_type != "gemini":
+            raise ValueError(f"Unsupported API type: {api_type}")
+        genai.configure(api_key=api_key)
+        return genai.GenerativeModel("gemini-2.5-pro")
+    if local_path:
+        print(f"⚠️ Local LLM path '{local_path}' provided but loading is not implemented.")
+        return None
+    print("🔑 Please set your Gemini API key in settings.json. See https://ai.google.dev/gemini-api")
+    return None
+
+
+def call_llm(model, prompt_text, temperature=0.6):
+    """Send ``prompt_text`` to the provided LLM model."""
+    if not model:
+        return "❌ Generative model not initialized."
+    try:
+        response = model.generate_content(
+            prompt_text,
+            generation_config={
+                "temperature": temperature,
+                "top_p": 1.0,
+                "max_output_tokens": 1000,
+            },
+        )
+        return response.text.strip()
+    except Exception as e:
+        return f"💥 Gemini query failed: {e}"

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,15 +1,28 @@
 {
   "_comment": "Copy this file to settings.json and modify as needed",
-  "api_key": "",
-  "context": {
-    "bidirectional": true,
-    "context_hops": 1,
-    "inbound_weight": 1.0,
-    "max_neighbors": 5,
-    "outbound_weight": 1.0
+  "LLM_model": {
+    "api_key": "",
+    "api_type": "gemini",
+    "local_path": ""
+  },
+  "paths": {
+    "output_dir": "extracted"
   },
   "embedding": {
     "embedding_dim": 384
+  },
+  "query": {
+    "top_k_results": 20,
+    "use_spellcheck": false,
+    "rephrase_count": 1,
+    "rephrase_model_path": ""
+  },
+  "context": {
+    "context_hops": 1,
+    "max_neighbors": 5,
+    "bidirectional": true,
+    "outbound_weight": 1.0,
+    "inbound_weight": 1.0
   },
   "extraction": {
     "allowed_extensions": [
@@ -24,7 +37,6 @@
       ".html",
       ".htm"
     ],
-    "comment_lookback_lines": 3,
     "exclude_dirs": [
       "__pycache__",
       ".git",
@@ -37,35 +49,24 @@
       ".vscode",
       ".pytest_cache"
     ],
+    "comment_lookback_lines": 3,
+    "token_estimate_ratio": 0.75,
     "minified_js_detection": {
       "max_lines_to_check": 50,
-      "required_long_lines": 2,
-      "single_line_threshold": 2000
-    },
-    "token_estimate_ratio": 0.75
-  },
-  "model": {
-    "llm_model": "BAAI/bge-small-en",
-    "local_model_path": ""
-  },
-  "paths": {
-    "output_dir": "extracted"
-  },
-  "query": {
-    "rephrase_count": 1,
-    "rephrase_model_path": "",
-    "top_k_results": 20,
-    "use_spellcheck": false
+      "single_line_threshold": 2000,
+      "required_long_lines": 2
+    }
   },
   "visualization": {
     "figsize": [
       12,
       10
     ],
-    "font_size": 8,
-    "node_color": "skyblue",
-    "node_size": 1500,
+    "spring_layout_k": 0.5,
     "spring_layout_iterations": 20,
-    "spring_layout_k": 0.5
-  }
+    "node_size": 1500,
+    "font_size": 8,
+    "node_color": "skyblue"
+  },
+  "encoder_model_path": ""
 }


### PR DESCRIPTION
## Summary
- restructure default settings for new `LLM_model` section
- add `encoder_model_path` setting at the bottom
- create `llm_utils` with helper to load/call Gemini API
- update `query_sniper` and `generate_embeddings` to use new settings
- regenerate `settings.example.json`
- document new configuration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d54b97844832ba615ec38959e7b6e