### PR TITLE
Add API settings defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ pytest -q
 - Settings are grouped into categories for easier navigation:
 
 - **LLM_model** – `api_key`, `api_type`, `local_path`
+- **api_settings** – `temperature`, `top_p`, `max_output_tokens`
 - **encoder_model_path** – location of the sentence transformer model
 - **paths** – `output_dir`
 - **embedding** – `embedding_dim`
@@ -80,6 +81,12 @@ Two optional features help refine search queries:
 
 Enable these options in `settings.json` under the `query` section. The `transformers`
 package will download the paraphrasing model the first time it is used.
+
+### API Settings
+
+The `api_settings` section controls parameters sent to the LLM API. Adjust
+`temperature`, `top_p`, and `max_output_tokens` to tune response style and length.
+The default `max_output_tokens` is **5000**.
 
 ### Debug Logging
 

--- a/Start.py
+++ b/Start.py
@@ -15,6 +15,11 @@ DEFAULT_SETTINGS = {
         "api_type": "gemini",
         "local_path": "",
     },
+    "api_settings": {
+        "temperature": 0.6,
+        "top_p": 1.0,
+        "max_output_tokens": 5000,
+    },
     "paths": {
         "output_dir": "extracted",
     },

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -22,17 +22,25 @@ def get_llm_model():
     return None
 
 
-def call_llm(model, prompt_text, temperature=0.6):
+def call_llm(model, prompt_text, temperature=None, max_tokens=None):
     """Send ``prompt_text`` to the provided LLM model."""
     if not model:
         return "❌ Generative model not initialized."
+
+    api_cfg = SETTINGS.get("api_settings", {})
+    if temperature is None:
+        temperature = api_cfg.get("temperature", 0.6)
+    if max_tokens is None:
+        max_tokens = api_cfg.get("max_output_tokens", 5000)
+    top_p = api_cfg.get("top_p", 1.0)
+
     try:
         response = model.generate_content(
             prompt_text,
             generation_config={
                 "temperature": temperature,
-                "top_p": 1.0,
-                "max_output_tokens": 1000,
+                "top_p": top_p,
+                "max_output_tokens": max_tokens,
             },
         )
         return response.text.strip()

--- a/settings.example.json
+++ b/settings.example.json
@@ -5,6 +5,11 @@
     "api_type": "gemini",
     "local_path": ""
   },
+  "api_settings": {
+    "temperature": 0.6,
+    "top_p": 1.0,
+    "max_output_tokens": 5000
+  },
   "paths": {
     "output_dir": "extracted"
   },

--- a/tests/test_settings_sync.py
+++ b/tests/test_settings_sync.py
@@ -14,3 +14,9 @@ def test_settings_example_matches_defaults(tmp_path, monkeypatch):
     data = json.loads(example.read_text())
     assert data == {"_comment": "Copy this file to settings.json and modify as needed", **DEFAULT_SETTINGS}
 
+
+def test_api_settings_defaults():
+    api = DEFAULT_SETTINGS["api_settings"]
+    assert api["max_output_tokens"] == 5000
+    assert api["temperature"] == 0.6
+


### PR DESCRIPTION
## Summary
- add `api_settings` to default configuration
- document API settings in README
- update example settings file
- use API settings in Gemini calls
- test new defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5b3b8340832bba74e33585e111d1