### PR TITLE
Add default download for missing encoder model

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ pytest -q
 
 - **LLM_model** – `api_key`, `api_type`, `local_path`
 - **api_settings** – `temperature`, `top_p`, `max_output_tokens`
-- **encoder_model_path** – location of the sentence transformer model
+ - **encoder_model_path** – location of the sentence transformer model. If left
+   blank, the small `sentence-transformers/all-MiniLM-L6-v2` model will be
+   downloaded automatically.
 - **paths** – `output_dir`
 - **embedding** – `embedding_dim`
 - **query** – `top_k_results`, `use_spellcheck`, `sub_question_count`

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -15,8 +15,12 @@ def main(project_folder):
 
     print("Loading embedding model...")
     if not model_path:
-        raise ValueError("encoder_model_path is not set in settings.json")
-    model = SentenceTransformer(model_path)
+        print(
+            "encoder_model_path is not set; downloading 'sentence-transformers/all-MiniLM-L6-v2'"
+        )
+        model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+    else:
+        model = SentenceTransformer(model_path)
 
     print(f"Loading call graph from {CALL_GRAPH_PATH} ...")
     with open(CALL_GRAPH_PATH, "r", encoding="utf-8") as f:

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -62,8 +62,12 @@ def main(project_folder):
     # --- Model and Data Loading ---
     print("🚀 Loading models and data...")
     if not model_path:
-        raise ValueError("encoder_model_path is not set in settings.json")
-    model = SentenceTransformer(model_path)
+        print(
+            "encoder_model_path is not set; downloading 'sentence-transformers/all-MiniLM-L6-v2'"
+        )
+        model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+    else:
+        model = SentenceTransformer(model_path)
     llm_model = get_llm_model()
     index = faiss.read_index(str(INDEX_PATH))
     with open(METADATA_PATH, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- make `generate_embeddings.py` and `query_sniper.py` download a default model when `encoder_model_path` is not provided
- document the new behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d61f8dbf8832b881042d2f8876db9