### PR TITLE
Move encoder_model_path into embedding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,13 @@ pytest -q
 
 - **LLM_model** – `api_key`, `api_type`, `local_path`
 - **api_settings** – `temperature`, `top_p`, `max_output_tokens`
-- **encoder_model_path** – location of the sentence transformer model
 - **paths** – `output_dir`
-- **embedding** – `embedding_dim`
 - **query** – `top_k_results`, `use_spellcheck`, `sub_question_count`
 - **context** – `context_hops`, `max_neighbors`, `bidirectional`
 - **extraction** – `allowed_extensions`, `exclude_dirs`, `comment_lookback_lines`,
   `token_estimate_ratio`, and `minified_js_detection` options
 - **visualization** – parameters controlling call graph rendering
+- **embedding** – `embedding_dim`, `encoder_model_path`
 
 The extraction step relies on `crawl_directory` which automatically skips files
 listed in `.gitignore` and only processes paths with extensions from

--- a/Start.py
+++ b/Start.py
@@ -23,9 +23,8 @@ DEFAULT_SETTINGS = {
     "paths": {
         "output_dir": "extracted",
     },
-    "embedding": {"embedding_dim": 384},
     "query": {
-        "top_k_results": 20,
+        "top_k_results": 5,
         "use_spellcheck": False,
         "sub_question_count": 0,
     },
@@ -77,7 +76,10 @@ DEFAULT_SETTINGS = {
         "font_size": 8,
         "node_color": "skyblue",
     },
-    "encoder_model_path": "",
+    "embedding": {
+        "embedding_dim": 384,
+        "encoder_model_path": "",
+    },
 }
 
 

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -11,11 +11,11 @@ def main(project_folder):
     CALL_GRAPH_PATH = Path(SETTINGS["paths"]["output_dir"]) / project_folder / "call_graph.json"
     OUTPUT_DIR = Path(SETTINGS["paths"]["output_dir"]) / project_folder
     EMBEDDING_DIM = SETTINGS["embedding"]["embedding_dim"]
-    model_path = SETTINGS.get("encoder_model_path")
+    model_path = SETTINGS.get("embedding", {}).get("encoder_model_path")
 
     print("Loading embedding model...")
     if not model_path:
-        raise ValueError("encoder_model_path is not set in settings.json")
+        raise ValueError("embedding.encoder_model_path is not set in settings.json")
     model = SentenceTransformer(model_path)
 
     print(f"Loading call graph from {CALL_GRAPH_PATH} ...")

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -46,7 +46,7 @@ def average_embeddings(model, texts) -> np.ndarray:
 def main(project_folder):
     """Interactive search of the generated embeddings."""
     # --- Configuration Loading ---
-    model_path = SETTINGS.get("encoder_model_path")
+    model_path = SETTINGS.get("embedding", {}).get("encoder_model_path")
     BASE_DIR = Path(SETTINGS["paths"]["output_dir"]) / project_folder
     METADATA_PATH = BASE_DIR / "embedding_metadata.json"
     INDEX_PATH = BASE_DIR / "faiss.index"
@@ -62,7 +62,7 @@ def main(project_folder):
     # --- Model and Data Loading ---
     print("🚀 Loading models and data...")
     if not model_path:
-        raise ValueError("encoder_model_path is not set in settings.json")
+        raise ValueError("embedding.encoder_model_path is not set in settings.json")
     model = SentenceTransformer(model_path)
     llm_model = get_llm_model()
     index = faiss.read_index(str(INDEX_PATH))

--- a/settings.example.json
+++ b/settings.example.json
@@ -13,11 +13,8 @@
   "paths": {
     "output_dir": "extracted"
   },
-  "embedding": {
-    "embedding_dim": 384
-  },
   "query": {
-    "top_k_results": 20,
+    "top_k_results": 5,
     "use_spellcheck": false,
     "sub_question_count": 0
   },
@@ -72,5 +69,8 @@
     "font_size": 8,
     "node_color": "skyblue"
   },
-  "encoder_model_path": ""
+  "embedding": {
+    "embedding_dim": 384,
+    "encoder_model_path": ""
+  }
 }


### PR DESCRIPTION
## Summary
- lower default `top_k_results` to 5
- relocate `encoder_model_path` under the `embedding` section
- update documentation for new settings layout
- adjust scripts to read `embedding.encoder_model_path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d63220944832baef225e02d964ab4