### PR TITLE
Remove unused utilities and cleanup imports

### DIFF
--- a/Start.py
+++ b/Start.py
@@ -194,12 +194,6 @@ def run_query(project_name):
     query_main(project_name)
 
 
-def run_inspect(project_name):
-    from inspect_graph import main as inspect_main
-    logger.info("Running graph inspection utility...")
-    inspect_main(project_name)
-
-
 def main():
     parser = argparse.ArgumentParser(description="LLM Extreme Context")
     parser.add_argument("path", nargs="?", help="Project directory to analyze")

--- a/context_utils.py
+++ b/context_utils.py
@@ -53,19 +53,6 @@ def expand_graph(
     return result
 
 
-def expand_neighborhood(
-    graph: dict, node_id: str, depth: int = 1, limit: int | None = None
-) -> list[str]:
-    """Backward compatible wrapper for expand_graph."""
-    return expand_graph(
-        graph,
-        node_id,
-        depth=depth,
-        limit=limit,
-        bidirectional=True,
-    )
-
-
 def gather_context(
     graph: dict,
     node_id: str,

--- a/inspect_graph.py
+++ b/inspect_graph.py
@@ -1,23 +1,8 @@
 import json
 from collections import Counter
 from pathlib import Path
-import matplotlib.pyplot as plt
-import networkx as nx
 
 from Start import SETTINGS
-
-def degree_plot(data):
-    G = nx.DiGraph()
-    for node in data["nodes"]:
-        G.add_node(node["id"])
-    for edge in data["edges"]:
-        G.add_edge(edge["from"], edge["to"])
-    degrees = [d for _, d in G.degree()]
-    plt.hist(degrees, bins=50)
-    plt.title("Node Degree Distribution")
-    plt.xlabel("Degree")
-    plt.ylabel("Count")
-    plt.show()
 
 def load_call_graph(path):
     with open(path, "r", encoding="utf-8") as f:

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -5,7 +5,7 @@ import sys
 import faiss
 import numpy as np
 from sentence_transformers import SentenceTransformer
-from symspellpy import SymSpell, Verbosity
+from symspellpy import SymSpell
 from llm_utils import get_llm_model, call_llm
 
 from context_utils import expand_graph


### PR DESCRIPTION
## Summary
- drop unused `Verbosity` import
- remove deprecated `expand_neighborhood`
- delete the `degree_plot` helper and its unused imports
- drop the unused `run_inspect` CLI function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d684b56ec832b9c316d9452f07f7f