### PR TITLE
Refactor settings and CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ those embeddings. The main scripts are located in the repository root.
 | `generate_embeddings.py` | Generates embeddings for call graph nodes using `sentence-transformers` and FAISS. |
 | `query_sniper.py` | Interactive CLI to search embeddings and explore neighboring nodes. |
 | `inspect_graph.py` | Basic analysis/visualization of the generated call graph. |
-| `Start.py` | Entry point providing `generate`, `query`, and `inspect` commands. |
+| `Start.py` | Unified CLI providing `extract`, `embed`, `query`, and `inspect` commands. |
 
 ## Function Relationships
 
@@ -36,6 +36,18 @@ those embeddings. The main scripts are located in the repository root.
 
 The `Start.py` module orchestrates these utilities via command line.
 
+### Usage Notes
+
+Run `python Start.py <command>` where `<command>` is one of:
+
+- `extract` – build a call graph for a project
+- `embed` – generate embeddings from a call graph
+- `query` – search the embeddings interactively
+- `inspect` – print basic graph statistics
+
+Running `Start.py` with just a path starts the interactive workflow. Command
+history is stored in `.full_context_history.json`.
+
 ### Debugging
 
 Scripts print detailed progress information when run with `PYTHONLOGLEVEL=DEBUG`.
@@ -51,3 +63,4 @@ pytest -q
 ```
 
 The main test file is `tests/test_extractors.py` which verifies the extractors and call graph generation.
+Always run `pytest -q` before committing changes.

--- a/LLM_Extreme_Context.py
+++ b/LLM_Extreme_Context.py
@@ -16,7 +16,7 @@ import pathspec
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 
-from Start import SETTINGS
+from config import SETTINGS
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 This project uses a `settings.json` file for configuration.
 If the file does not exist it will be created automatically with default values.
-The `settings.example.json` file is kept in sync with the defaults in `Start.py`
-whenever the tools run, so copying that file is an easy way to start customising
-your own settings. The extractors handle Python, HTML, Markdown, and JavaScript
-source files using tree-sitter for the latter.
+The `settings.example.json` file is kept in sync with the defaults whenever the
+tools run, so copying that file is an easy way to start customizing your own
+settings. The extractors handle Python, HTML, Markdown, and JavaScript source
+files using tree-sitter for the latter.
 
 ### Installation
 
@@ -16,6 +16,13 @@ Install dependencies with:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Workflow
+
+1. **extract** – parse source files and build a call graph
+2. **embed** – generate embeddings for each node
+3. **query** – interactively search the embeddings
+4. **inspect** – optional graph statistics and visualisation
 
 If `sub_question_count` is greater than 0, an LLM call breaks your question into
 that many sub-queries before searching the embeddings. This helps find relevant
@@ -54,7 +61,7 @@ callees. Set it to `False` to only follow outgoing calls.
 ### Files
 
  - `LLM_Extreme_Context.py`: Extracts Python, HTML, Markdown, and JavaScript using tree-sitter
-- `Start.py`: Entry point for running other utilities
+ - `Start.py`: Unified CLI with `extract`, `embed`, `query`, and `inspect` commands
 - `generate_embeddings.py`: Generate embeddings from call graph
 - `query_sniper.py`: Interactive query interface
 - `inspect_graph.py`: Graph analysis and visualization
@@ -64,8 +71,16 @@ callees. Set it to `False` to only follow outgoing calls.
 ## Usage
 
 The `settings.json` file is automatically loaded by all scripts. If the file doesn't exist, it will be generated with defaults the first time you run the tools.
-Run `python Start.py [path]` where `path` is the folder you want to analyse. If the artifacts for that project do not exist they will be created and you will then be dropped into the interactive query interface.
-While in the query interface you can type `neighbors <n>` to see the graph neighbors of result `n` from the previous search.
+Invoke the CLI with `python Start.py <command>`:
+
+```bash
+python Start.py extract /path/to/project
+python Start.py embed my_project
+python Start.py query my_project --problem "bug" --prompt "search term"
+python Start.py inspect my_project
+```
+
+Running `Start.py` with just a path enters an interactive loop. While querying you can type `neighbors <n>` to see the graph neighbors of result `n` from the previous search. Interactive prompts are stored in `.full_context_history.json`.
 
 ### Spellcheck and Sub-Queries
 

--- a/Start.py
+++ b/Start.py
@@ -1,216 +1,23 @@
-import os
-import re
-import json
 import argparse
 import logging
 from pathlib import Path
 
 from user_interaction import start_event, after_generation_event, _load_history
+from config import (
+    SETTINGS,
+    reload_settings,
+    DEFAULT_SETTINGS,
+    ensure_example_settings,
+    load_settings,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Default configuration used by all tools
-DEFAULT_SETTINGS = {
-    "LLM_model": {
-        "api_key": "",
-        "api_type": "gemini",
-        "local_path": "",
-    },
-    "api_settings": {
-        "temperature": 0.6,
-        "top_p": 1.0,
-        "max_output_tokens": 5000,
-    },
-    "paths": {
-        "output_dir": "extracted",
-    },
-    "query": {
-        "top_k_results": 5,
-        "use_spellcheck": False,
-        "sub_question_count": 0,
-        "prompt_suggestion_count": 0,
-    },
-    "context": {
-        "context_hops": 1,
-        "max_neighbors": 5,
-        "bidirectional": True,
-        "outbound_weight": 1.0,
-        "inbound_weight": 1.0,
-    },
-    "extraction": {
-        "allowed_extensions": [
-            ".py",
-            ".js",
-            ".ts",
-            ".json",
-            ".yaml",
-            ".yml",
-            ".md",
-            ".txt",
-            ".html",
-            ".htm",
-        ],
-        "exclude_dirs": [
-            "__pycache__",
-            ".git",
-            "node_modules",
-            ".venv",
-            "venv",
-            "dist",
-            "build",
-            ".idea",
-            ".vscode",
-            ".pytest_cache",
-        ],
-        "comment_lookback_lines": 3,
-        "token_estimate_ratio": 0.75,
-        "minified_js_detection": {
-            "max_lines_to_check": 50,
-            "single_line_threshold": 2000,
-            "required_long_lines": 2,
-        },
-    },
-    "visualization": {
-        "figsize": [12, 10],
-        "spring_layout_k": 0.5,
-        "spring_layout_iterations": 20,
-        "node_size": 1500,
-        "font_size": 8,
-        "node_color": "skyblue",
-    },
-    "embedding": {
-        "embedding_dim": 384,
-        "encoder_model_path": "",
-    },
-}
 
-
-
-def ensure_example_settings():
-    """Synchronize settings.example.json with DEFAULT_SETTINGS."""
-
-    example_path = "settings.example.json"
-    template = {"_comment": "Copy this file to settings.json and modify as needed"}
-    template.update(DEFAULT_SETTINGS)
-
-    current = {}
-    if os.path.exists(example_path):
-        try:
-            with open(example_path, "r", encoding="utf-8") as f:
-                current = json.load(f)
-        except (json.JSONDecodeError, IOError):
-            current = {}
-
-    if current != template:
-        with open(example_path, "w", encoding="utf-8") as f:
-            json.dump(template, f, indent=2)
-            f.write("\n")
-        logger.info("Updated %s with default settings", example_path)
-
-
-def load_settings():
-    """
-    Load settings from `settings.json`, fixing common path formatting errors if needed.
-
-    If the file is missing, it's created with defaults. If it fails to load due
-    to a JSON error (often from unescaped backslashes in Windows paths), this
-    function will attempt to fix the paths in the raw text and reload.
-    """
-    ensure_example_settings()
-
-    settings_path = "settings.json"
-    settings = {}
-
-    if os.path.exists(settings_path):
-        try:
-            with open(settings_path, "r", encoding="utf-8") as f:
-                settings = json.load(f)
-                logger.info("Successfully loaded settings.json")
-        except (json.JSONDecodeError, IOError) as e:
-            try:
-                with open(settings_path, "r", encoding="utf-8") as f_read:
-                    content = f_read.read()
-
-                # This regex finds key-value pairs where the key suggests a path,
-                # allowing us to surgically fix path strings without corrupting other data.
-                path_pattern = re.compile(
-                    r'('
-                    # Group 1: The key and opening quote of the value, e.g., '"output_dir": "'
-                    r'"(?:[a-zA-Z0-9_]*_)?(?:path|dir|root|model|output|folder|file|location|destination)(?:_[a-zA-Z0-9_]*)?"'
-                    r'\s*:\s*"'
-                    r')'
-                    # Group 2: The value itself, containing the path.
-                    r'([^"]*)'
-                    # Group 3: The closing quote.
-                    r'(")'
-                )
-
-                def path_replacer(match):
-                    """Normalizes path separators to be valid in JSON."""
-                    pre_value, path_value, post_value = match.groups()
-                    # Normalize all path separators to a single forward slash first.
-                    normalized = path_value.replace('\\\\', '/').replace('\\', '/')
-                    # Convert all forward slashes to double backslashes for JSON.
-                    fixed_path = normalized.replace('/', '\\\\')
-                    return f'{pre_value}{fixed_path}{post_value}'
-
-                fixed_content = path_pattern.sub(path_replacer, content)
-
-                settings = json.loads(fixed_content)
-                logger.info("Successfully loaded settings.json after auto-fixing paths.")
-
-            except (json.JSONDecodeError, IOError) as e2:
-                logger.error(
-                    f"Failed to load settings.json even after attempting to fix paths: {e2}. "
-                    "Please check the file for syntax errors. Using defaults."
-                )
-                settings = {}  # Fallback to empty dict
-    else:
-        logger.info("settings.json not found. Creating one with default settings.")
-        settings = json.loads(json.dumps(DEFAULT_SETTINGS))
-        try:
-            with open(settings_path, "w", encoding="utf-8") as f:
-                json.dump(settings, f, indent=2)
-                f.write("\n")
-        except IOError as e:
-            logger.warning(f"Failed to write settings.json: {e}")
-
-    def ensure_keys(defaults, target):
-        changed = False
-        for k, v in defaults.items():
-            if k not in target:
-                target[k] = v
-                changed = True
-            elif isinstance(v, dict) and isinstance(target[k], dict):
-                if ensure_keys(v, target[k]):
-                    changed = True
-        return changed
-
-    ensure_keys(DEFAULT_SETTINGS, settings)
-
-    def deep_merge(defaults, overrides):
-        result = defaults.copy()
-        for k, v in overrides.items():
-            if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-                result[k] = deep_merge(result[k], v)
-            else:
-                result[k] = v
-        return result
-
-    return deep_merge(DEFAULT_SETTINGS, settings)
-
-
-SETTINGS = load_settings()
-
-
-def run_extract(project_path: Path, project_name: str):
-    """Extract functions from the project and build the call graph."""
-    from LLM_Extreme_Context import (
-        crawl_directory,
-        build_call_graph,
-        save_graph_json,
-    )
+def run_extract(project_path: Path, project_name: str) -> None:
+    """Extract functions and build the call graph."""
+    from LLM_Extreme_Context import crawl_directory, build_call_graph, save_graph_json
 
     logger.info("Crawling source files in %s", project_path)
     entries = crawl_directory(str(project_path), respect_gitignore=True)
@@ -223,24 +30,64 @@ def run_extract(project_path: Path, project_name: str):
     logger.info("Saved call graph to %s", graph_path)
 
 
-def run_generate_embeddings(project_name):
+def run_generate_embeddings(project_name: str) -> None:
     from generate_embeddings import main as gen_main
+
     logger.info("Generating embeddings for %s", project_name)
     gen_main(project_name)
 
 
-def run_query(project_name, problem, prompt):
+def run_query(project_name: str, problem: str | None, prompt: str | None) -> None:
     from query_sniper import main as query_main
+
     logger.info("Launching query tool...")
     query_main(project_name, problem, initial_query=prompt)
 
 
-def main():
+def run_inspect(project_name: str) -> None:
+    from inspect_graph import main as inspect_main
+
+    inspect_main(project_name)
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(description="LLM Extreme Context")
-    parser.add_argument("path", nargs="?", help="Project directory to analyze")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_extract = sub.add_parser("extract", help="Extract source and build call graph")
+    p_extract.add_argument("path")
+
+    p_embed = sub.add_parser("embed", help="Generate embeddings for project")
+    p_embed.add_argument("project")
+
+    p_query = sub.add_parser("query", help="Search embeddings")
+    p_query.add_argument("project")
+    p_query.add_argument("--problem")
+    p_query.add_argument("--prompt")
+
+    p_inspect = sub.add_parser("inspect", help="Inspect call graph")
+    p_inspect.add_argument("project")
+
+    parser.add_argument("path", nargs="?", help="Project directory for interactive mode")
+
     args = parser.parse_args()
 
+    reload_settings()
     _load_history()
+
+    if args.cmd == "extract":
+        path = Path(args.path).resolve()
+        run_extract(path, path.name)
+        return
+    if args.cmd == "embed":
+        run_generate_embeddings(args.project)
+        return
+    if args.cmd == "query":
+        run_query(args.project, args.problem, args.prompt)
+        return
+    if args.cmd == "inspect":
+        run_inspect(args.project)
+        return
 
     while True:
         if args.path:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,190 @@
+# Configuration module for LLM Extreme Context
+import os
+import json
+import re
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default configuration used by all tools
+DEFAULT_SETTINGS = {
+    "LLM_model": {
+        "api_key": "",
+        "api_type": "gemini",
+        "local_path": "",
+    },
+    "api_settings": {
+        "temperature": 0.6,
+        "top_p": 1.0,
+        "max_output_tokens": 5000,
+    },
+    "paths": {
+        "output_dir": "extracted",
+    },
+    "query": {
+        "top_k_results": 5,
+        "use_spellcheck": False,
+        "sub_question_count": 0,
+        "prompt_suggestion_count": 0,
+    },
+    "context": {
+        "context_hops": 1,
+        "max_neighbors": 5,
+        "bidirectional": True,
+        "outbound_weight": 1.0,
+        "inbound_weight": 1.0,
+    },
+    "extraction": {
+        "allowed_extensions": [
+            ".py",
+            ".js",
+            ".ts",
+            ".json",
+            ".yaml",
+            ".yml",
+            ".md",
+            ".txt",
+            ".html",
+            ".htm",
+        ],
+        "exclude_dirs": [
+            "__pycache__",
+            ".git",
+            "node_modules",
+            ".venv",
+            "venv",
+            "dist",
+            "build",
+            ".idea",
+            ".vscode",
+            ".pytest_cache",
+        ],
+        "comment_lookback_lines": 3,
+        "token_estimate_ratio": 0.75,
+        "minified_js_detection": {
+            "max_lines_to_check": 50,
+            "single_line_threshold": 2000,
+            "required_long_lines": 2,
+        },
+    },
+    "visualization": {
+        "figsize": [12, 10],
+        "spring_layout_k": 0.5,
+        "spring_layout_iterations": 20,
+        "node_size": 1500,
+        "font_size": 8,
+        "node_color": "skyblue",
+    },
+    "embedding": {
+        "embedding_dim": 384,
+        "encoder_model_path": "",
+    },
+}
+
+
+SETTINGS = {}
+
+
+def ensure_example_settings():
+    """Synchronize settings.example.json with DEFAULT_SETTINGS."""
+    example_path = "settings.example.json"
+    template = {"_comment": "Copy this file to settings.json and modify as needed"}
+    template.update(DEFAULT_SETTINGS)
+
+    current = {}
+    if os.path.exists(example_path):
+        try:
+            with open(example_path, "r", encoding="utf-8") as f:
+                current = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            current = {}
+
+    if current != template:
+        with open(example_path, "w", encoding="utf-8") as f:
+            json.dump(template, f, indent=2)
+            f.write("\n")
+        logger.info("Updated %s with default settings", example_path)
+
+
+def _fix_paths(content: str) -> str:
+    path_pattern = re.compile(
+        r'("(?:[a-zA-Z0-9_]*_)?(?:path|dir|root|model|output|folder|file|location|destination)(?:_[a-zA-Z0-9_]*)?"\s*:\s*")([^"]*)(")'
+    )
+
+    def path_replacer(match):
+        pre_value, path_value, post_value = match.groups()
+        normalized = path_value.replace('\\\\', '/').replace('\\', '/')
+        fixed_path = normalized.replace('/', '\\\\')
+        return f"{pre_value}{fixed_path}{post_value}"
+
+    return path_pattern.sub(path_replacer, content)
+
+
+def load_settings() -> dict:
+    """Load settings from ``settings.json`` or create defaults."""
+    ensure_example_settings()
+    settings_path = "settings.json"
+    settings = {}
+
+    if os.path.exists(settings_path):
+        try:
+            with open(settings_path, "r", encoding="utf-8") as f:
+                settings = json.load(f)
+                logger.info("Successfully loaded settings.json")
+        except (json.JSONDecodeError, IOError):
+            try:
+                with open(settings_path, "r", encoding="utf-8") as f_read:
+                    content = f_read.read()
+                fixed_content = _fix_paths(content)
+                settings = json.loads(fixed_content)
+                logger.info("Successfully loaded settings.json after auto-fixing paths.")
+            except (json.JSONDecodeError, IOError) as e2:
+                logger.error(
+                    "Failed to load settings.json even after attempting to fix paths: %s. Using defaults.",
+                    e2,
+                )
+                settings = {}
+    else:
+        logger.info("settings.json not found. Creating one with default settings.")
+        settings = json.loads(json.dumps(DEFAULT_SETTINGS))
+        try:
+            with open(settings_path, "w", encoding="utf-8") as f:
+                json.dump(settings, f, indent=2)
+                f.write("\n")
+        except IOError as e:
+            logger.warning("Failed to write settings.json: %s", e)
+
+    def ensure_keys(defaults, target):
+        changed = False
+        for k, v in defaults.items():
+            if k not in target:
+                target[k] = v
+                changed = True
+            elif isinstance(v, dict) and isinstance(target[k], dict):
+                if ensure_keys(v, target[k]):
+                    changed = True
+        return changed
+
+    ensure_keys(DEFAULT_SETTINGS, settings)
+
+    def deep_merge(defaults, overrides):
+        result = defaults.copy()
+        for k, v in overrides.items():
+            if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+                result[k] = deep_merge(result[k], v)
+            else:
+                result[k] = v
+        return result
+
+    return deep_merge(DEFAULT_SETTINGS, settings)
+
+
+def reload_settings() -> None:
+    """Reload settings from disk into the ``SETTINGS`` dict."""
+    SETTINGS.clear()
+    SETTINGS.update(load_settings())
+
+
+# Load settings on import
+reload_settings()

--- a/generate_embeddings.py
+++ b/generate_embeddings.py
@@ -2,24 +2,18 @@ import json
 import numpy as np
 import faiss
 from pathlib import Path
-from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 from context_utils import gather_context
 
-from Start import SETTINGS
+from config import SETTINGS
+from llm_utils import load_embedding_model
 def main(project_folder):
     CALL_GRAPH_PATH = Path(SETTINGS["paths"]["output_dir"]) / project_folder / "call_graph.json"
     OUTPUT_DIR = Path(SETTINGS["paths"]["output_dir"]) / project_folder
     model_path = SETTINGS.get("embedding", {}).get("encoder_model_path")
 
     print("Loading embedding model...")
-    if not model_path:
-        print(
-            "encoder_model_path is not set; downloading 'sentence-transformers/all-MiniLM-L6-v2'"
-        )
-        model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
-    else:
-        model = SentenceTransformer(model_path)
+    model = load_embedding_model(model_path)
 
     EMBEDDING_DIM = model.get_sentence_embedding_dimension()
     print(f"Detected embedding dimension: {EMBEDDING_DIM}")

--- a/inspect_graph.py
+++ b/inspect_graph.py
@@ -2,7 +2,7 @@ import json
 from collections import Counter
 from pathlib import Path
 
-from Start import SETTINGS
+from config import SETTINGS
 
 def load_call_graph(path):
     with open(path, "r", encoding="utf-8") as f:

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,6 +1,6 @@
 from google import genai
-from google.genai import types
-from Start import SETTINGS
+from sentence_transformers import SentenceTransformer
+from config import SETTINGS
 
 # Only Gemini is supported right now
 
@@ -50,3 +50,14 @@ def call_llm(client, prompt_text, temperature=None, max_tokens=None, top_p=None)
         return response.text.strip()
     except Exception as e:
         return f"💥 Gemini query failed: {e}"
+
+
+def load_embedding_model(model_path: str | None):
+    """Load a ``SentenceTransformer`` model from ``model_path`` or download a default."""
+    if not model_path:
+        print(
+            "encoder_model_path is not set; downloading 'sentence-transformers/all-MiniLM-L6-v2'"
+        )
+        return SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+    return SentenceTransformer(model_path)
+

--- a/query_sniper.py
+++ b/query_sniper.py
@@ -4,9 +4,8 @@ import sys
 
 import faiss
 import numpy as np
-from sentence_transformers import SentenceTransformer
 from symspellpy import SymSpell
-from llm_utils import get_llm_model, call_llm
+from llm_utils import get_llm_model, call_llm, load_embedding_model
 
 def get_example_json(n):
     return ",\n  ".join(f'"query suggestion {i+1}"' for i in range(n))
@@ -50,7 +49,7 @@ Respond only with the query string.
 from context_utils import expand_graph
 from summary_formatter import format_summary
 from prompt_builder import build_prompt
-from Start import SETTINGS
+from config import SETTINGS
 
 def build_symspell(metadata):
     """Builds a SymSpell dictionary for spell correction."""
@@ -127,13 +126,7 @@ def main(project_folder, problem=None, initial_query=None):
 
     # --- Model and Data Loading ---
     print("🚀 Loading models and data...")
-    if not model_path:
-        print(
-            "encoder_model_path is not set; downloading 'sentence-transformers/all-MiniLM-L6-v2'"
-        )
-        model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
-    else:
-        model = SentenceTransformer(model_path)
+    model = load_embedding_model(model_path)
     llm_model = get_llm_model()
     index = faiss.read_index(str(INDEX_PATH))
     with open(METADATA_PATH, "r", encoding="utf-8") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ numpy
 pyyaml
 pathspec
 symspellpy
-transformers
 google-genai

--- a/user_interaction.py
+++ b/user_interaction.py
@@ -106,10 +106,10 @@ def ask_search_prompt() -> str:
 def change_settings_event() -> None:
     """Interactively change values in ``settings.json``."""
 
-    import Start  # Local import to avoid circular dependency
+    import config
 
     settings_path = Path("settings.json")
-    settings = Start.load_settings()
+    settings = config.load_settings()
 
     while True:
         print("\nCurrent settings:")
@@ -145,6 +145,5 @@ def change_settings_event() -> None:
     except Exception as e:  # pragma: no cover - don't fail interactivity
         print(f"Failed to save settings: {e}")
 
-    Start.SETTINGS.clear()
-    Start.SETTINGS.update(Start.load_settings())
+    config.reload_settings()
 


### PR DESCRIPTION
## Summary
- centralize configuration in new `config.py`
- overhaul `Start.py` into a unified CLI
- update modules to use the config module
- add embedding model loader utility
- streamline requirements
- document workflow and usage
- clarify contribution notes in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e603494d0832bb24cd6aa1cf70328