### PR TITLE
Refactor spellcheck into standalone utility

### DIFF
--- a/spellcheck_utils.py
+++ b/spellcheck_utils.py
@@ -1,0 +1,18 @@
+from symspellpy import SymSpell
+
+
+def create_symspell_from_terms(terms, max_distance=2, prefix_length=7):
+    """Create a SymSpell dictionary from an iterable of terms."""
+    sym = SymSpell(max_dictionary_edit_distance=max_distance, prefix_length=prefix_length)
+    for term in terms:
+        for token in str(term).split():
+            sym.create_dictionary_entry(token, 1)
+    return sym
+
+
+def correct_phrase(symspell, phrase, max_edit_distance=2):
+    """Return the best correction for ``phrase`` using ``symspell``."""
+    if not symspell:
+        return phrase
+    suggestions = symspell.lookup_compound(phrase, max_edit_distance=max_edit_distance)
+    return suggestions[0].term if suggestions else phrase

--- a/tests/test_query_features.py
+++ b/tests/test_query_features.py
@@ -4,8 +4,9 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from Start import DEFAULT_SETTINGS
-from query_sniper import build_symspell, correct_query, average_embeddings
+from config import DEFAULT_SETTINGS
+from spellcheck_utils import create_symspell_from_terms, correct_phrase
+from query_sniper import average_embeddings
 
 
 def test_default_query_settings():
@@ -16,9 +17,9 @@ def test_default_query_settings():
 
 
 def test_spellcheck_basic():
-    metadata = [{"name": "foobar"}]
-    sym = build_symspell(metadata)
-    corrected = correct_query(sym, "foobzr")
+    terms = ["foobar"]
+    sym = create_symspell_from_terms(terms)
+    corrected = correct_phrase(sym, "foobzr")
     assert corrected == "foobar"
 
 

--- a/tests/test_settings_sync.py
+++ b/tests/test_settings_sync.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from Start import DEFAULT_SETTINGS, ensure_example_settings
+from config import DEFAULT_SETTINGS, ensure_example_settings
 
 
 def test_settings_example_matches_defaults(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- move spell check logic into `spellcheck_utils.py`
- update `query_sniper` to use generic `create_symspell_from_terms` and `correct_phrase`
- adjust tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e928070a8832b8ac3618bf0c965e7