### PR TITLE
Improve session logging and add tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -80,6 +80,12 @@ DEFAULT_SETTINGS = {
         "embedding_dim": 384,
         "encoder_model_path": "",
     },
+    "logging": {
+        "log_markdown": True,
+        "log_json": True,
+        "track_duplicates": True,
+        "max_functions_to_log": 100,
+    },
 }
 
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -73,5 +73,11 @@
   "embedding": {
     "embedding_dim": 384,
     "encoder_model_path": ""
+  },
+  "logging": {
+    "log_markdown": true,
+    "log_json": true,
+    "track_duplicates": true,
+    "max_functions_to_log": 100
   }
 }

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -1,0 +1,33 @@
+import re
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config import DEFAULT_SETTINGS
+from session_logger import log_session_to_json, log_summary_to_markdown
+
+
+def test_logging_defaults_present():
+    logging_cfg = DEFAULT_SETTINGS["logging"]
+    assert logging_cfg["log_markdown"] is True
+    assert logging_cfg["log_json"] is True
+    assert logging_cfg["track_duplicates"] is True
+    assert logging_cfg["max_functions_to_log"] == 100
+
+
+def test_session_logger_writes_files(tmp_path):
+    data = {
+        "original_query": "Find foo",
+        "subqueries": [
+            {"text": "foo", "functions": []}
+        ],
+        "functions": {},
+    }
+    json_path = log_session_to_json(data, tmp_path)
+    md_path = log_summary_to_markdown(data, tmp_path)
+    assert Path(json_path).exists()
+    assert Path(md_path).exists()
+    assert re.search(r"query_find_foo_", Path(json_path).name)
+    assert re.search(r"query_find_foo_", Path(md_path).name)
+


### PR DESCRIPTION
## Summary
- extend configuration with new `logging` section
- enhance JSON/Markdown logging with duplicate and core hit tracking
- include log file slug in output filenames
- add configurable logging in query workflow
- test session logging helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb24224e0832ba1f579bb928b0803