### PR TITLE
Add call graph roles and score aggregation

### DIFF
--- a/session_logger.py
+++ b/session_logger.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from datetime import datetime
+import json
 import re
 
 
@@ -16,12 +17,52 @@ def get_timestamp() -> str:
     return datetime.utcnow().strftime("%Y-%m-%dT%H%MZ")
 
 
+def format_function_entry(node: dict, relevance: dict, graph: dict) -> dict:
+    """Return structured JSON for a single function node."""
+    callers = []
+    for cid in node.get("called_by", []):
+        edge = next((e for e in graph.get("edges", []) if e["from"] == cid and e["to"] == node["id"]), None)
+        count = edge.get("weight", 1) if edge else 1
+        caller_node = next((n for n in graph.get("nodes", []) if n["id"] == cid), {})
+        callers.append({
+            "function": caller_node.get("name", cid.split("::")[-1]),
+            "file": caller_node.get("file_path"),
+            "count": count,
+        })
+
+    callees = []
+    for cid in node.get("calls", []):
+        edge = next((e for e in graph.get("edges", []) if e["from"] == node["id"] and e["to"] == cid), None)
+        count = edge.get("weight", 1) if edge else 1
+        callee_node = next((n for n in graph.get("nodes", []) if n["id"] == cid), {})
+        callees.append({
+            "function": callee_node.get("name", cid.split("::")[-1]),
+            "file": callee_node.get("file_path"),
+            "count": count,
+        })
+
+    return {
+        "function_name": node.get("name"),
+        "file": node.get("file_path"),
+        "class": node.get("class"),
+        "relevance_scores": relevance,
+        "call_relations": {
+            "callers": callers,
+            "callees": callees,
+        },
+        "call_graph_role": node.get("call_graph_role"),
+        "parameters": node.get("parameters", {}),
+        "comment": (node.get("docstring") or " ").strip(),
+        "code": node.get("code", ""),
+    }
+
+
 def log_session_to_json(data: dict, path: str) -> str:
     """Write session data to ``path`` in JSON format and return file path."""
     logs = Path(path)
     logs.mkdir(parents=True, exist_ok=True)
-    slug = slugify(data.get("original_query", "query"))
-    fname = f"query_{slug}_{get_timestamp()}.json"
+    slug = slugify(data.get("query", data.get("original_query", "query")))
+    fname = f"{get_timestamp()}_{slug}.json"
     full_path = logs / fname
     with open(full_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)

--- a/tests/test_call_roles.py
+++ b/tests/test_call_roles.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import graph
+
+CODE = """
+def a():
+    b()
+
+def b():
+    c()
+
+def c():
+    pass
+
+def d():
+    pass
+"""
+
+def test_call_graph_roles(tmp_path):
+    f = tmp_path / "sample.py"
+    f.write_text(CODE)
+    entries = graph.extract_from_python(str(f))
+    G = graph.build_call_graph(entries)
+    out = tmp_path / "graph.json"
+    graph.save_graph_json(G, out)
+    data = json.loads(out.read_text())
+    roles = {n["name"]: n["call_graph_role"] for n in data["nodes"]}
+    assert roles["a"] == "entrypoint"
+    assert roles["b"] == "middleware"
+    assert roles["c"] == "leaf"
+    assert roles["d"] == "orphan"

--- a/tests/test_score_aggregation.py
+++ b/tests/test_score_aggregation.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from query import aggregate_scores
+
+
+def test_aggregate_scores_basic():
+    data = {
+        "foo": {
+            "subqueries": [
+                {"index": 0, "text": "q1", "score": 0.8, "rank": 1},
+                {"index": 1, "text": "q2", "score": 0.6, "rank": 2},
+            ]
+        }
+    }
+    agg = aggregate_scores(data)
+    assert "foo" in agg
+    assert np.isclose(agg["foo"]["avg_score"], 0.7)
+    assert np.isclose(agg["foo"]["max_score"], 0.8)
+    assert np.isclose(agg["foo"]["stddev_score"], np.std([0.8,0.6]))
+    assert agg["foo"]["queries_matched"] == ["q1","q2"]

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -18,16 +18,16 @@ def test_logging_defaults_present():
 
 def test_session_logger_writes_files(tmp_path):
     data = {
-        "original_query": "Find foo",
+        "query": "Find foo",
         "subqueries": [
             {"text": "foo", "functions": []}
         ],
         "functions": {},
     }
     json_path = log_session_to_json(data, tmp_path)
-    md_path = log_summary_to_markdown(data, tmp_path)
+    md_path = log_summary_to_markdown({"original_query": "Find foo", "subqueries": [], "functions": {}}, tmp_path)
     assert Path(json_path).exists()
     assert Path(md_path).exists()
-    assert re.search(r"query_find_foo_", Path(json_path).name)
+    assert re.search(r"find_foo\.json$", Path(json_path).name)
     assert re.search(r"query_find_foo_", Path(md_path).name)
 


### PR DESCRIPTION
## Summary
- parse function parameters and docstrings in Python extractor
- infer call graph roles and include them in saved graph JSON
- aggregate search relevance scores per function
- format function results for JSON logging
- adjust session logging filename pattern
- update tests and add coverage for new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ecce84e78832b968462a159d0ae64