### PR TITLE
Add JSON prompt builder and function summary

### DIFF
--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -219,3 +219,15 @@ def build_prompt(
         Path(save_path).write_text("\n\n".join(blocks_full), encoding="utf-8")
         print(f"🗃 Output saved to: {save_path}")
     return result
+
+
+def build_json_prompt(function_objects, user_question, save_path=None):
+    data = {
+        "question": user_question,
+        "functions": function_objects,
+    }
+    text = json.dumps(data, indent=2)
+    if save_path:
+        with open(save_path, "w", encoding="utf-8") as f:
+            f.write(text)
+    return text


### PR DESCRIPTION
## Summary
- create `build_json_prompt` in `prompt_builder`
- replace prompt builder call to use JSON objects
- build detailed `full_function_objects` during query
- print function summaries with call graph roles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edca12234832b87c422a6b7c52353