### PR TITLE
Optimize import loading

### DIFF
--- a/embedding.py
+++ b/embedding.py
@@ -1,16 +1,13 @@
 import json
 from pathlib import Path
-import numpy as np
-import faiss
-from tqdm import tqdm
-from sentence_transformers import SentenceTransformer
-
 from config import SETTINGS
-from graph import gather_context
+from lazy_loader import lazy_import
 
 
 def load_embedding_model(model_path: str | None):
     """Load a ``SentenceTransformer`` model or download a default."""
+    model_lib = lazy_import("sentence_transformers")
+    SentenceTransformer = model_lib.SentenceTransformer
     if not model_path:
         print(
             "encoder_model_path is not set; downloading 'sentence-transformers/all-MiniLM-L6-v2'"
@@ -44,10 +41,16 @@ def generate_embeddings(project_folder: str) -> None:
     out_w = SETTINGS["context"].get("outbound_weight", 1.0)
     in_w = SETTINGS["context"].get("inbound_weight", 1.0)
 
+    graph_mod = lazy_import("graph")
+    np = lazy_import("numpy")
+    faiss = lazy_import("faiss")
+    tqdm_mod = lazy_import("tqdm")
+    tqdm = tqdm_mod.tqdm
+
     print("Encoding function nodes...")
     for node in tqdm(nodes, desc="Gathering context", unit="node"):
         name = node.get("name", "")
-        context = gather_context(
+        context = graph_mod.gather_context(
             graph,
             node["id"],
             depth=depth,

--- a/lazy_loader.py
+++ b/lazy_loader.py
@@ -1,0 +1,8 @@
+import importlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+def lazy_import(module_name: str):
+    logger.debug("Loading module %s", module_name)
+    return importlib.import_module(module_name)

--- a/llm.py
+++ b/llm.py
@@ -1,7 +1,5 @@
-from google import genai
-from google.genai import types
-from sentence_transformers import SentenceTransformer
 from config import SETTINGS
+from lazy_loader import lazy_import
 import json
 
 
@@ -57,7 +55,7 @@ def get_llm_model():
     if api_key:
         if api_type != "gemini":
             raise ValueError(f"Unsupported API type: {api_type}")
-        # Using Client for more versatile use cases like file uploads
+        genai = lazy_import("google.generativeai")
         client = genai.Client(api_key=api_key)
         return client
     if local_path:
@@ -82,6 +80,7 @@ def call_llm(client, prompt_text, temperature=None, max_tokens=None, top_p=None)
         max_tokens = api_cfg.get("max_output_tokens", 5000)
     top_p = api_cfg.get("top_p", 1.0)
 
+    types = lazy_import("google.generativeai.types")
     try:
         response = client.models.generate_content(
             model="gemini-2.5-pro",

--- a/workspace.py
+++ b/workspace.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 import json
-import faiss
-
-from embedding import load_embedding_model
+from lazy_loader import lazy_import
 from config import SETTINGS
 
 
@@ -18,7 +16,7 @@ class DataWorkspace:
     metadata: list = field(default_factory=list)
     graph: dict = field(default_factory=dict)
     node_map: dict = field(default_factory=dict)
-    index: faiss.Index | None = None
+    index: object | None = None
     model: object | None = None
 
     @classmethod
@@ -30,7 +28,9 @@ class DataWorkspace:
         index_path = base_dir / "faiss.index"
         model_path = SETTINGS.get("embedding", {}).get("encoder_model_path")
 
-        model = load_embedding_model(model_path)
+        embedding = lazy_import("embedding")
+        faiss = lazy_import("faiss")
+        model = embedding.load_embedding_model(model_path)
         index = faiss.read_index(str(index_path))
         with open(metadata_path, "r", encoding="utf-8") as f:
             metadata = json.load(f)


### PR DESCRIPTION
## Summary
- add a `lazy_loader` helper to log and perform imports when needed
- lazy load heavy modules in the CLI and main entrypoint
- update embedding, query, workspace and llm logic to delay imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f73b9da80832ba6efb349bfed18cf