### PR TITLE
Expand call graph and add TypeScript support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,11 @@ those embeddings. The main scripts are located in the repository root.
 ## Function Relationships
 
 1. **Extraction** – `graph.extract_from_python`,
-   `extract_from_html`, `extract_from_markdown`, and
-   `extract_from_javascript` parse files and return a
-   list of entries. `build_call_graph` then creates a `networkx` graph from
-   these entries and `save_graph_json` writes it to disk.
+   `extract_from_html`, `extract_from_markdown`,
+   `extract_from_javascript`, and `extract_from_typescript` parse files
+   and return a list of entries. `build_call_graph` adds every entry to a
+   `networkx` graph (not just functions) and `save_graph_json` writes it to
+   disk.
 2. **Context Gathering** – `graph.gather_context` collects code from related
    nodes using `expand_graph`. Direction can be controlled with the
    `bidirectional` setting.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This project uses a `settings.json` file for configuration.
 If the file does not exist it will be created automatically with default values.
 The `settings.example.json` file is kept in sync with the defaults whenever the
 tools run, so copying that file is an easy way to start customizing your own
-settings. The extractors handle Python, HTML, Markdown, and JavaScript source
-files using tree-sitter for the latter.
+settings. The extractors handle Python, HTML, Markdown, JavaScript, and
+TypeScript source files using tree-sitter for the latter. JSON, YAML, and
+plain text files are also parsed so every piece of content can be searched.
 
 ### Installation
 
@@ -90,7 +91,7 @@ Running `main.py` without arguments starts an interactive loop. It will prompt f
 Two optional features help refine search queries:
 
 - **use_spellcheck** – when `true`, the query is corrected using SymSpell before searching.
-  A small dictionary is built from function names automatically, but you can also
+  A small dictionary is built from item names automatically, but you can also
   download a larger frequency dictionary from the SymSpell repository and place it
   in the project root.
 - **sub_question_count** – when greater than 0, your question is first sent to the

--- a/embedding.py
+++ b/embedding.py
@@ -47,9 +47,9 @@ def generate_embeddings(project_folder: str) -> None:
     tqdm_mod = lazy_import("tqdm")
     tqdm = tqdm_mod.tqdm
 
-    print("Encoding function nodes...")
+    print("Encoding nodes...")
     for node in tqdm(nodes, desc="Gathering context", unit="node"):
-        name = node.get("name", "")
+        name = node.get("name") or node.get("type", "")
         context = graph_mod.gather_context(
             graph,
             node["id"],

--- a/session_logger.py
+++ b/session_logger.py
@@ -41,8 +41,9 @@ def format_function_entry(node: dict, relevance: dict, graph: dict) -> dict:
             "count": count,
         })
 
+    name = node.get("name") or node.get("type")
     return {
-        "function_name": node.get("name"),
+        "function_name": name,
         "file": node.get("file_path"),
         "class": node.get("class"),
         "relevance_scores": relevance,

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -154,6 +154,25 @@ const qux = async (z) => {
     assert "foo" in baz_entry["called_functions"]
 
 
+def test_extract_from_typescript(tmp_path):
+    code = """
+function foo(a: number) {
+    return a + 1;
+}
+
+const bar = (x: number) => {
+    return foo(x);
+};
+"""
+    f = tmp_path / "sample.ts"
+    f.write_text(code)
+    results = lec.extract_from_typescript(str(f))
+    names = {r["name"] for r in results}
+    assert names == {"foo", "bar"}
+    bar_entry = next(r for r in results if r["name"] == "bar")
+    assert "foo" in bar_entry["called_functions"]
+
+
 def test_extract_from_json(tmp_path):
     data = {"a": 1, "b": {"c": 2}}
     f = tmp_path / "config.json"

--- a/tests/test_non_function_nodes.py
+++ b/tests/test_non_function_nodes.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import graph as lec
+import embedding
+from config import SETTINGS
+
+
+def test_non_function_nodes(tmp_path, monkeypatch):
+    (tmp_path / "main.py").write_text("def foo():\n    pass\n")
+    (tmp_path / "doc.md").write_text("# Title\ntext")
+    (tmp_path / "page.html").write_text("<body><!-- hi --></body>")
+    (tmp_path / "conf.json").write_text('{"a": 1}')
+    (tmp_path / "conf.yaml").write_text('a: b')
+    (tmp_path / "notes.txt").write_text('note')
+
+    entries = lec.crawl_directory(str(tmp_path), respect_gitignore=False)
+    G = lec.build_call_graph(entries)
+    types = {d["type"] for _, d in G.nodes(data=True)}
+    assert {"function", "section", "html_section", "config_entry", "raw_text"} <= types
+
+    project = "proj"
+    out_dir = tmp_path / "out"
+    monkeypatch.setitem(SETTINGS["paths"], "output_dir", str(out_dir))
+    out_proj = out_dir / project
+    out_proj.mkdir(parents=True)
+    lec.save_graph_json(G, out_proj / "call_graph.json")
+
+    class DummyModel:
+        def get_sentence_embedding_dimension(self):
+            return 2
+        def encode(self, texts, normalize_embeddings=True, show_progress_bar=True):
+            return [[0.0, 0.0] for _ in texts]
+
+    class DummyFaiss:
+        class IndexFlatIP:
+            def __init__(self, dim):
+                self.vecs = []
+            def add(self, arr):
+                self.vecs.extend(arr)
+        def write_index(self, index, path):
+            Path(path).write_text("index")
+
+    monkeypatch.setattr(embedding, "load_embedding_model", lambda _: DummyModel())
+    sys.modules["faiss"] = DummyFaiss()
+
+    embedding.generate_embeddings(project)
+
+    meta = json.loads((out_proj / "embedding_metadata.json").read_text())
+    graph_data = json.loads((out_proj / "call_graph.json").read_text())
+    id_to_type = {n["id"]: n["type"] for n in graph_data["nodes"]}
+    meta_types = {id_to_type[m["id"]] for m in meta}
+    assert {"function", "section", "html_section", "config_entry", "raw_text"} <= meta_types
+


### PR DESCRIPTION
## Summary
- include all extractor outputs in the call graph
- add TypeScript extractor and `.ts` extension mapping
- handle unnamed nodes throughout querying and logging
- generalise prompt text from "Function" to "Item"
- embed every node type
- test extraction for TypeScript and ensure non-function nodes are embedded
- document new behaviour in README and AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd4f821a0832b9d65b50eaf73145e