### PR TITLE
Revamp query output structure

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ DEFAULT_SETTINGS = {
         "max_output_tokens": 5000,
     },
     "paths": {
-        "output_dir": "extracted",
+        "output_dir": "output",
     },
     "query": {
         "top_k_results": 5,

--- a/session_logger.py
+++ b/session_logger.py
@@ -58,26 +58,34 @@ def format_function_entry(node: dict, relevance: dict, graph: dict) -> dict:
     }
 
 
-def log_session_to_json(data: dict, path: str) -> str:
+def log_session_to_json(data: dict, path: str | Path) -> str:
     """Write session data to ``path`` in JSON format and return file path."""
-    logs = Path(path)
-    logs.mkdir(parents=True, exist_ok=True)
-    slug = slugify(data.get("query", data.get("original_query", "query")))
-    fname = f"{get_timestamp()}_{slug}.json"
-    full_path = logs / fname
+    dest = Path(path)
+    if dest.suffix:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        full_path = dest
+    else:
+        dest.mkdir(parents=True, exist_ok=True)
+        slug = slugify(data.get("query", data.get("original_query", "query")))
+        fname = f"{get_timestamp()}_{slug}.json"
+        full_path = dest / fname
     with open(full_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
         f.write("\n")
     return str(full_path)
 
 
-def log_summary_to_markdown(data: dict, path: str) -> str:
+def log_summary_to_markdown(data: dict, path: str | Path) -> str:
     """Write a human-readable summary of ``data`` to ``path`` and return file path."""
-    logs = Path(path)
-    logs.mkdir(parents=True, exist_ok=True)
-    slug = slugify(data.get("original_query", "query"))
-    fname = f"query_{slug}_{get_timestamp()}.md"
-    full_path = logs / fname
+    dest = Path(path)
+    if dest.suffix:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        full_path = dest
+    else:
+        dest.mkdir(parents=True, exist_ok=True)
+        slug = slugify(data.get("original_query", "query"))
+        fname = f"query_{slug}_{get_timestamp()}.md"
+        full_path = dest / fname
 
     subqueries = data.get("subqueries", [])
     functions = data.get("functions", {})

--- a/settings.example.json
+++ b/settings.example.json
@@ -11,7 +11,7 @@
     "max_output_tokens": 5000
   },
   "paths": {
-    "output_dir": "extracted"
+    "output_dir": "output"
   },
   "query": {
     "top_k_results": 5,

--- a/workspace.py
+++ b/workspace.py
@@ -59,3 +59,4 @@ class QuerySession:
     function_matches: dict[str, dict] = field(default_factory=dict)
     final_indices: list[int] = field(default_factory=list)
     llm_response: str = ""
+    output_dir: Path | None = None


### PR DESCRIPTION
## Summary
- change default `output_dir` to `output`
- allow QuerySession to record output directory
- extend session_logger to accept explicit file paths
- store query results in run-specific directories with `manifest.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff715f2d4832bb20d26e208c664f8