### PR TITLE
Add default instruction for LLM calls

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -55,7 +55,7 @@ def get_llm_model():
     if api_key:
         if api_type != "gemini":
             raise ValueError(f"Unsupported API type: {api_type}")
-        genai = lazy_import("google.generativeai")
+        genai = lazy_import("google.genai")
         client = genai.Client(api_key=api_key)
         return client
     if local_path:
@@ -66,7 +66,11 @@ def get_llm_model():
 
 
 def call_llm(client, prompt_text, temperature=None, max_tokens=None, top_p=None):
-    """Send ``prompt_text`` to the provided LLM client."""
+    """Send ``prompt_text`` to the provided LLM client.
+
+    A short system instruction is sent with every request to
+    encourage the model to follow the prompts.
+    """
     if not client:
         return "❌ Generative model client not initialized."
     
@@ -80,7 +84,9 @@ def call_llm(client, prompt_text, temperature=None, max_tokens=None, top_p=None)
         max_tokens = api_cfg.get("max_output_tokens", 5000)
     top_p = api_cfg.get("top_p", 1.0)
 
-    types = lazy_import("google.generativeai.types")
+    instruction = "Your job is to process and format data."
+
+    types = lazy_import("google.genai.types")
     try:
         response = client.models.generate_content(
             model="gemini-2.5-pro",
@@ -89,6 +95,7 @@ def call_llm(client, prompt_text, temperature=None, max_tokens=None, top_p=None)
                 temperature=temperature,
                 max_output_tokens=max_tokens,
                 top_p=top_p,
+                system_instruction=instruction,
             ),
         )
         raw_text = (


### PR DESCRIPTION
## Summary
- prepend system instruction to every Gemini request via GenerateContentConfig
- use google.genai module path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fff450b80832bbab1d78c6ae34e1f