### PR TITLE
Add auto_visualize setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ pytest -q
 - **context** – `context_hops`, `max_neighbors`, `bidirectional`
 - **extraction** – `allowed_extensions`, `exclude_dirs`, `comment_lookback_lines`,
   `token_estimate_ratio`, and `minified_js_detection` options
-- **visualization** – parameters controlling call graph rendering
+- **visualization** – parameters controlling call graph rendering; set
+  `auto_visualize` to `true` to automatically save a PNG after extraction
 - **embedding** – `embedding_dim`, `encoder_model_path`
 
 The extraction step relies on `crawl_directory` which automatically skips files

--- a/config.py
+++ b/config.py
@@ -84,6 +84,7 @@ DEFAULT_SETTINGS = {
         "node_size": 1500,
         "font_size": 8,
         "node_color": "skyblue",
+        "auto_visualize": False,
     },
     "embedding": {
         "embedding_dim": 384,

--- a/main.py
+++ b/main.py
@@ -93,9 +93,11 @@ def main() -> None:
 
     reload_settings()
 
+    visualize_cfg = SETTINGS.get("visualization", {}).get("auto_visualize", False)
+
     if args.cmd == "extract":
         path = Path(args.path).resolve()
-        run_extract(path, path.name, visualize=args.visualize)
+        run_extract(path, path.name, visualize=args.visualize or visualize_cfg)
         return
     if args.cmd == "embed":
         run_generate_embeddings(args.project)
@@ -130,7 +132,7 @@ def main() -> None:
 
         if not call_graph_path.exists():
             logger.info("Extracting project and building call graph...")
-            run_extract(project_path, project_name)
+            run_extract(project_path, project_name, visualize=visualize_cfg)
         else:
             logger.info("Using existing call graph at %s", call_graph_path)
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -68,17 +68,18 @@
       "required_long_lines": 2
     }
   },
-  "visualization": {
-    "figsize": [
-      12,
-      10
-    ],
-    "spring_layout_k": 0.5,
-    "spring_layout_iterations": 20,
-    "node_size": 1500,
-    "font_size": 8,
-    "node_color": "skyblue"
-  },
+    "visualization": {
+      "figsize": [
+        12,
+        10
+      ],
+      "spring_layout_k": 0.5,
+      "spring_layout_iterations": 20,
+      "node_size": 1500,
+      "font_size": 8,
+      "node_color": "skyblue",
+      "auto_visualize": false
+    },
   "embedding": {
     "embedding_dim": 384,
     "encoder_model_path": ""

--- a/tests/test_settings_sync.py
+++ b/tests/test_settings_sync.py
@@ -20,3 +20,8 @@ def test_api_settings_defaults():
     assert api["max_output_tokens"] == 5000
     assert api["temperature"] == 0.6
 
+
+def test_visualization_auto_setting():
+    vis = DEFAULT_SETTINGS["visualization"]
+    assert vis["auto_visualize"] is False
+


### PR DESCRIPTION
## Summary
- add `auto_visualize` option to default configuration and example file
- respect the setting in the CLI when extracting projects
- document the new option
- test that the default is present in settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800f056a30832b84c9b2aa9d506086