### PR TITLE
Use relative file paths

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -506,7 +506,8 @@ def crawl_directory(root: str, respect_gitignore: bool = True) -> List[Dict]:
             paths.append((dirpath, filename))
 
     for dirpath, filename in tqdm(paths, desc="Scanning files", unit="file"):
-        rel = os.path.relpath(os.path.join(dirpath, filename), root)
+        full_path = os.path.join(dirpath, filename)
+        rel = os.path.relpath(full_path, root)
         ext = os.path.splitext(filename)[1].lower()
         if ext not in ALLOWED_EXTENSIONS:
             logger.debug("Skipping %s: extension not allowed", rel)
@@ -518,7 +519,9 @@ def crawl_directory(root: str, respect_gitignore: bool = True) -> List[Dict]:
             continue
         extractor = EXTENSION_MAP.get(ext)
         if extractor:
-            entries = extractor(os.path.join(dirpath, filename))
+            entries = extractor(full_path)
+            for entry in entries:
+                entry["file_path"] = rel
         else:
             logger.debug("Skipping %s: no extractor", rel)
             SKIPPED_LOG.append({"file": rel, "reason": "no extractor"})

--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -41,10 +41,13 @@ def format_summary(
         file_path = node.get("file_path", meta.get("file"))
         display_path = file_path
         if base_dir:
-            try:
-                display_path = str(Path(file_path).resolve().relative_to(Path(base_dir).resolve()))
-            except Exception:
-                pass
+            base = Path(base_dir)
+            p = Path(file_path)
+            if p.is_absolute():
+                try:
+                    display_path = str(p.relative_to(base))
+                except Exception:
+                    display_path = str(p.name)
         lang = node.get("language", "unknown")
         tokens = node.get("estimated_tokens", 0)
 
@@ -163,10 +166,13 @@ def build_prompt(
         file_path = node.get("file_path", meta.get("file", "unknown"))
         display_path = file_path
         if base_dir:
-            try:
-                display_path = str(Path(file_path).resolve().relative_to(Path(base_dir).resolve()))
-            except Exception:
-                pass
+            base = Path(base_dir)
+            p = Path(file_path)
+            if p.is_absolute():
+                try:
+                    display_path = str(p.relative_to(base))
+                except Exception:
+                    display_path = str(p.name)
         comments = node.get("comments", [])[:5]
         calls = [node_map.get(cid, {}).get("name", cid) for cid in node.get("calls", [])]
         called_by = [node_map.get(cid, {}).get("name", cid) for cid in node.get("called_by", [])]


### PR DESCRIPTION
## Summary
- return relative file paths when crawling directories
- avoid leaking absolute paths when building summaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688016d67e80832bba83b2d25393acce