### PR TITLE
Add checksum validation for workspace artifacts

### DIFF
--- a/embedding.py
+++ b/embedding.py
@@ -30,6 +30,7 @@ def generate_embeddings(project_folder: str) -> None:
     print(f"Loading call graph from {call_graph_path} ...")
     with open(call_graph_path, "r", encoding="utf-8") as f:
         graph = json.load(f)
+    graph_checksum = graph.get("checksum")
 
     nodes = graph["nodes"]
     texts = []
@@ -73,8 +74,12 @@ def generate_embeddings(project_folder: str) -> None:
     np.save(output_dir / "embeddings.npy", embeddings)
 
     meta_file = output_dir / "embedding_metadata.json"
+    meta_out = {
+        "graph_checksum": graph_checksum,
+        "records": metadata,
+    }
     with open(meta_file, "w", encoding="utf-8") as f:
-        json.dump(metadata, f, indent=2)
+        json.dump(meta_out, f, indent=2)
     print(f"🗃 Output saved to: {meta_file}")
 
     index = faiss.IndexFlatIP(embedding_dim)

--- a/graph.py
+++ b/graph.py
@@ -632,6 +632,13 @@ def save_graph_json(graph: nx.DiGraph, path: Path):
         data["nodes"].append({"id": node, **graph.nodes[node], "calls": calls, "called_by": called_by})
     for u, v, d in graph.edges(data=True):
         data["edges"].append({"from": u, "to": v, "weight": d.get("weight", 1)})
+
+    base_data = {"nodes": data["nodes"], "edges": data["edges"]}
+    checksum = hashlib.sha256(
+        json.dumps(base_data, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    data["checksum"] = checksum
+
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     print(f"🗃 Output saved to: {path}")
 

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -1,0 +1,58 @@
+import json
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import graph
+import workspace
+import embedding
+from config import SETTINGS
+
+
+def test_workspace_checksum_validation(tmp_path, monkeypatch):
+    project = "proj"
+    out_dir = tmp_path / project
+    out_dir.mkdir()
+    monkeypatch.setitem(SETTINGS["paths"], "output_dir", str(tmp_path))
+
+    # build minimal graph
+    G = graph.build_call_graph([])
+    node_id = "file.py::foo"
+    G.add_node(node_id, file_path="file.py", type="function", name="foo")
+    graph.save_graph_json(G, out_dir / "call_graph.json")
+    graph_data = json.loads((out_dir / "call_graph.json").read_text())
+    checksum = graph_data["checksum"]
+
+    # dummy embedding artifacts
+    np.save(out_dir / "embeddings.npy", np.zeros((1, 2)))
+    (out_dir / "faiss.index").write_text("index")
+
+    class DummyModel:
+        def get_sentence_embedding_dimension(self):
+            return 2
+
+    class DummyFaiss:
+        @staticmethod
+        def read_index(path):
+            return "index"
+
+    sys.modules["faiss"] = DummyFaiss
+    monkeypatch.setattr(embedding, "load_embedding_model", lambda _: DummyModel())
+
+    meta = {
+        "graph_checksum": checksum,
+        "records": [{"id": node_id, "file": "file.py", "name": "foo"}],
+    }
+    (out_dir / "embedding_metadata.json").write_text(json.dumps(meta))
+
+    ws = workspace.DataWorkspace.load(project)
+    assert ws.graph["checksum"] == checksum
+
+    # mismatch should raise
+    meta["graph_checksum"] = "bad"
+    (out_dir / "embedding_metadata.json").write_text(json.dumps(meta))
+    with pytest.raises(RuntimeError):
+        workspace.DataWorkspace.load(project)

--- a/tests/test_non_function_nodes.py
+++ b/tests/test_non_function_nodes.py
@@ -49,8 +49,10 @@ def test_non_function_nodes(tmp_path, monkeypatch):
 
     embedding.generate_embeddings(project)
 
-    meta = json.loads((out_proj / "embedding_metadata.json").read_text())
+    meta_raw = json.loads((out_proj / "embedding_metadata.json").read_text())
     graph_data = json.loads((out_proj / "call_graph.json").read_text())
+    assert meta_raw["graph_checksum"] == graph_data["checksum"]
+    meta = meta_raw["records"]
     id_to_type = {n["id"]: n["type"] for n in graph_data["nodes"]}
     meta_types = {id_to_type[m["id"]] for m in meta}
     assert meta_types == {"function"}


### PR DESCRIPTION
## Summary
- embed graph checksum in `call_graph.json`
- pass graph checksum into `embedding_metadata.json`
- validate checksums when loading a `DataWorkspace`
- adjust tests for new metadata format
- add regression test for checksum mismatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801a73d204832b98ea86eb8254806d