### PR TITLE
Remove deprecated embedding_dim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pytest -q
   `token_estimate_ratio`, and `minified_js_detection` options
 - **visualization** – parameters controlling call graph rendering; set
   `auto_visualize` to `true` to automatically save a PNG after extraction
-- **embedding** – `embedding_dim`, `encoder_model_path`
+- **embedding** – `encoder_model_path`
 
 The extraction step relies on `crawl_directory` which automatically skips files
 listed in `.gitignore` and only processes paths with extensions from

--- a/config.py
+++ b/config.py
@@ -89,7 +89,6 @@ DEFAULT_SETTINGS = {
         "auto_visualize": False,
     },
     "embedding": {
-        "embedding_dim": 384,
         "encoder_model_path": "",
     },
     "logging": {
@@ -109,6 +108,10 @@ def ensure_example_settings():
     example_path = "settings.example.json"
     template = {"_comment": "Copy this file to settings.json and modify as needed"}
     template.update(DEFAULT_SETTINGS)
+    # Mark removed options so users know they are deprecated
+    template.setdefault("embedding", {})["_deprecated_embedding_dim"] = (
+        "formerly controlled embedding size"
+    )
 
     current = {}
     if os.path.exists(example_path):

--- a/settings.example.json
+++ b/settings.example.json
@@ -83,8 +83,8 @@
       "auto_visualize": false
     },
   "embedding": {
-    "embedding_dim": 384,
-    "encoder_model_path": ""
+    "encoder_model_path": "",
+    "_deprecated_embedding_dim": "formerly controlled embedding size"
   },
   "logging": {
     "log_markdown": true,

--- a/tests/test_settings_sync.py
+++ b/tests/test_settings_sync.py
@@ -12,7 +12,10 @@ def test_settings_example_matches_defaults(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     ensure_example_settings()
     data = json.loads(example.read_text())
-    assert data == {"_comment": "Copy this file to settings.json and modify as needed", **DEFAULT_SETTINGS}
+    expected = {"_comment": "Copy this file to settings.json and modify as needed"}
+    expected.update(json.loads(json.dumps(DEFAULT_SETTINGS)))
+    expected["embedding"]["_deprecated_embedding_dim"] = "formerly controlled embedding size"
+    assert data == expected
 
 
 def test_api_settings_defaults():


### PR DESCRIPTION
## Summary
- drop `embedding_dim` from default embedding settings
- mention only `encoder_model_path` in the README
- add a deprecation note to `settings.example.json`
- update settings sync test for new example format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801eac06e4832b8e9837fe162916af