### PR TITLE
Streamline interactive query workflow

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,6 @@ DEFAULT_SETTINGS = {
         "top_k_results": 5,
         "use_spellcheck": False,
         "sub_question_count": 0,
-        "prompt_suggestion_count": 3,
     },
     "context": {
         "context_hops": 1,

--- a/settings.example.json
+++ b/settings.example.json
@@ -18,8 +18,7 @@
   "query": {
     "top_k_results": 5,
     "use_spellcheck": false,
-    "sub_question_count": 0,
-    "prompt_suggestion_count": 3
+    "sub_question_count": 0
   },
   "context": {
     "context_hops": 1,

--- a/tests/test_query_features.py
+++ b/tests/test_query_features.py
@@ -13,7 +13,6 @@ def test_default_query_settings():
     q = DEFAULT_SETTINGS["query"]
     assert q["use_spellcheck"] is False
     assert q["sub_question_count"] == 0
-    assert q["prompt_suggestion_count"] == 3
 
 
 def test_spellcheck_basic():


### PR DESCRIPTION
## Summary
- simplify interactive prompts
- drop obsolete prompt suggestion settings
- streamline `query.main` to run a single search cycle
- update CLI for new workflow
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ed21f59c832b921c3332324119f9