### PR TITLE
Handle triple-quoted LLM responses

### DIFF
--- a/tests/test_parse_llm_response.py
+++ b/tests/test_parse_llm_response.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from query import parse_llm_response
+
+
+def test_parse_llm_response_triple_quotes():
+    text = "'''\n{\"response_type\": \"functions\", \"functions\": [\"foo\"], \"total\": 1}\n'''"
+    result = parse_llm_response(text)
+    assert result == {"response_type": "functions", "functions": ["foo"], "total": 1}
+


### PR DESCRIPTION
## Summary
- improve `parse_llm_response` to strip triple quotes and code fences
- add unit test for parsing triple quoted JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810430d818832ba35f984ed97fc3c5